### PR TITLE
✨ market crud api & maket's candle read api & money topup api & realtime-tick websocket & candle data scheduler add

### DIFF
--- a/src/main/java/com/hackathon/tomolow/TomolowBeApplication.java
+++ b/src/main/java/com/hackathon/tomolow/TomolowBeApplication.java
@@ -3,9 +3,11 @@ package com.hackathon.tomolow;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing // Spring Data JPA에서, Auditing(감시)기능을 활성화하는 어노테이션
+@EnableScheduling
 public class TomolowBeApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/hackathon/tomolow/domain/candle/controller/CandleController.java
+++ b/src/main/java/com/hackathon/tomolow/domain/candle/controller/CandleController.java
@@ -1,0 +1,42 @@
+package com.hackathon.tomolow.domain.candle.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.hackathon.tomolow.domain.candle.dto.request.CandleTf;
+import com.hackathon.tomolow.domain.candle.dto.response.CandlePointResponse;
+import com.hackathon.tomolow.domain.candle.service.CandleQueryService;
+import com.hackathon.tomolow.global.response.BaseResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/candles")
+@Tag(name = "Candles", description = "차트용 캔들 조회 API")
+public class CandleController {
+
+  private final CandleQueryService candleQueryService;
+
+  // 예) /api/candles/KRW-BTC?tf=D1&limit=365
+  //    /api/candles/KRW-BTC?tf=W1&limit=104
+  //    /api/candles/KRW-BTC?tf=M3&limit=40
+  @Operation(summary = "캔들 조회", description = "1D/1W/1M/3M 단위로 캔들을 집계하여 반환")
+  @GetMapping("/{symbol}")
+  public ResponseEntity<BaseResponse<List<CandlePointResponse>>> get(
+      @PathVariable String symbol,
+      @RequestParam(defaultValue = "D1") String tf,
+      @RequestParam(required = false) Integer limit) {
+    List<CandlePointResponse> body =
+        candleQueryService.getCandles(symbol, CandleTf.from(tf), limit);
+    return ResponseEntity.ok(BaseResponse.success("캔들 조회 성공", body));
+  }
+}

--- a/src/main/java/com/hackathon/tomolow/domain/candle/dto/UpbitDayCandle.java
+++ b/src/main/java/com/hackathon/tomolow/domain/candle/dto/UpbitDayCandle.java
@@ -1,0 +1,53 @@
+package com.hackathon.tomolow.domain.candle.dto;
+
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true) // ✅ 모르는 필드 무시 (market 외 여분 필드 방어)
+@Schema(title = "UpbitDayCandle DTO", description = "업비트 REST API로부터 받아오는 일봉(1D) 데이터")
+public class UpbitDayCandle {
+
+  @Schema(description = "마켓 코드", example = "KRW-BTC")
+  @JsonProperty("market") // 에러의 직접 원인 필드 추가
+  private String market;
+
+  @Schema(description = "KST 기준 캔들 시간", example = "2025-11-05T00:00:00")
+  @JsonProperty("candle_date_time_kst")
+  private String candleDateTimeKst;
+
+  @Schema(description = "시가 (Opening price)", example = "115000.0")
+  @JsonProperty("opening_price")
+  private BigDecimal openingPrice;
+
+  @Schema(description = "고가 (Highest price)", example = "118000.0")
+  @JsonProperty("high_price")
+  private BigDecimal highPrice;
+
+  @Schema(description = "저가 (Lowest price)", example = "113000.0")
+  @JsonProperty("low_price")
+  private BigDecimal lowPrice;
+
+  @Schema(description = "종가 (Closing price)", example = "117000.0")
+  @JsonProperty("trade_price")
+  private BigDecimal tradePrice;
+
+  @Schema(description = "누적 거래량 (수량 기준)", example = "1532.45")
+  @JsonProperty("candle_acc_trade_volume")
+  private BigDecimal accTradeVolume;
+
+  @Schema(description = "누적 거래대금 (원화 기준)", example = "176204000.0")
+  @JsonProperty("candle_acc_trade_price")
+  private BigDecimal accTradePrice;
+}

--- a/src/main/java/com/hackathon/tomolow/domain/candle/dto/request/CandleTf.java
+++ b/src/main/java/com/hackathon/tomolow/domain/candle/dto/request/CandleTf.java
@@ -1,0 +1,13 @@
+package com.hackathon.tomolow.domain.candle.dto.request;
+
+public enum CandleTf {
+  D1, // 1일
+  W1, // 1주
+  M1, // 1개월
+  M3,
+  Y1; // 3개월
+
+  public static CandleTf from(String v) {
+    return CandleTf.valueOf(v.toUpperCase());
+  }
+}

--- a/src/main/java/com/hackathon/tomolow/domain/candle/dto/response/CandlePointResponse.java
+++ b/src/main/java/com/hackathon/tomolow/domain/candle/dto/response/CandlePointResponse.java
@@ -1,0 +1,39 @@
+package com.hackathon.tomolow.domain.candle.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(title = "CandlePoint", description = "차트의 한 캔들 데이터")
+public class CandlePointResponse {
+
+  @Schema(description = "캔들 시작(KST)")
+  private LocalDateTime startTime;
+
+  @Schema(description = "캔들 끝(KST) - 집계 구간의 종료 지점(포함/표시는 클라에서)")
+  private LocalDateTime endTime;
+
+  @Schema(description = "시가")
+  private BigDecimal open;
+
+  @Schema(description = "고가")
+  private BigDecimal high;
+
+  @Schema(description = "저가")
+  private BigDecimal low;
+
+  @Schema(description = "종가")
+  private BigDecimal close;
+
+  @Schema(description = "거래량(합)")
+  private BigDecimal volume;
+}

--- a/src/main/java/com/hackathon/tomolow/domain/candle/repository/CandleRepository.java
+++ b/src/main/java/com/hackathon/tomolow/domain/candle/repository/CandleRepository.java
@@ -1,7 +1,27 @@
 package com.hackathon.tomolow.domain.candle.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.hackathon.tomolow.domain.candle.entity.Candle;
+import com.hackathon.tomolow.domain.market.entity.Market;
 
-public interface CandleRepository extends JpaRepository<Candle, Long> {}
+public interface CandleRepository extends JpaRepository<Candle, Long> {
+
+  Optional<Candle> findByMarketAndStartTimeAndIntervalMin(
+      Market market, LocalDateTime start, Long intervalMin);
+
+  // 최근 2개 일봉(가장 최근=오늘/전일)이면 [0]=최근, [1]=전일
+  List<Candle> findTop2ByMarketAndIntervalMinOrderByStartTimeDesc(Market market, Long intervalMin);
+
+  // 저장은 1일봉만 하기로 했으므로 interval_min = 1440 고정
+  List<Candle> findByMarket_SymbolAndIntervalMinAndStartTimeBetweenOrderByStartTimeAsc(
+      String symbol, Long intervalMin, LocalDateTime from, LocalDateTime to);
+
+  // 기간 제한 없이 전부 (차트 최신 limit개만 잘라 쓰기)
+  List<Candle> findByMarket_SymbolAndIntervalMinOrderByStartTimeAsc(
+      String symbol, Long intervalMin);
+}

--- a/src/main/java/com/hackathon/tomolow/domain/candle/service/CandleIngestService.java
+++ b/src/main/java/com/hackathon/tomolow/domain/candle/service/CandleIngestService.java
@@ -1,0 +1,70 @@
+package com.hackathon.tomolow.domain.candle.service;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.hackathon.tomolow.domain.candle.dto.UpbitDayCandle;
+import com.hackathon.tomolow.domain.candle.entity.Candle;
+import com.hackathon.tomolow.domain.candle.repository.CandleRepository;
+import com.hackathon.tomolow.domain.market.entity.Market;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CandleIngestService {
+
+  private static final long INTERVAL_1D = 1440L;
+  private static final DateTimeFormatter KST = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+
+  private final UpbitRestClient upbit;
+  private final CandleRepository candleRepo;
+
+  @Transactional
+  public int upsertDayCandles(Market market, int count) throws Exception {
+    List<UpbitDayCandle> rows = upbit.getDayCandles(market.getSymbol(), count);
+    int saved = 0;
+
+    for (UpbitDayCandle r : rows) {
+      LocalDateTime start = LocalDateTime.parse(r.getCandleDateTimeKst(), KST);
+
+      // 유니크키(market_id, start_time, interval_min)로 중복 방지
+      if (candleRepo
+          .findByMarketAndStartTimeAndIntervalMin(market, start, INTERVAL_1D)
+          .isPresent()) {
+        continue;
+      }
+
+      // ⚠️ volume 컬럼 선택: 수량으로 저장할지(아래) 금액으로 저장할지 결정
+      // - 수량: r.getAccTradeVolume()
+      // - 원화금액(권장, 그래프 합산 이해 쉬움): r.getAccTradePrice()
+      BigDecimal volume = r.getAccTradeVolume(); // 원화로 하려면 getAccTradePrice()
+
+      Candle entity =
+          Candle.builder()
+              .market(market)
+              .startTime(start)
+              .intervalMin(INTERVAL_1D)
+              .openPrice(r.getOpeningPrice())
+              .highPrice(r.getHighPrice())
+              .lowPrice(r.getLowPrice())
+              .closePrice(r.getTradePrice())
+              .volume(volume)
+              .build();
+
+      candleRepo.save(entity);
+      saved++;
+    }
+
+    log.info(
+        "Upsert 1D candles: {} saved={} (symbol={})", market.getName(), saved, market.getSymbol());
+    return saved;
+  }
+}

--- a/src/main/java/com/hackathon/tomolow/domain/candle/service/CandleQueryService.java
+++ b/src/main/java/com/hackathon/tomolow/domain/candle/service/CandleQueryService.java
@@ -1,0 +1,202 @@
+package com.hackathon.tomolow.domain.candle.service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.WeekFields;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.hackathon.tomolow.domain.candle.dto.request.CandleTf;
+import com.hackathon.tomolow.domain.candle.dto.response.CandlePointResponse;
+import com.hackathon.tomolow.domain.candle.entity.Candle;
+import com.hackathon.tomolow.domain.candle.repository.CandleRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CandleQueryService {
+
+  private final CandleRepository candleRepo;
+
+  private static final long DAILY = 1440L; // 1일봉만 DB 저장
+
+  // KST 기준으로 보정
+  private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+  public List<CandlePointResponse> getCandles(String symbol, CandleTf tf, Integer limit) {
+    // 1) 전체 1일봉 가져오기 (필요시 날짜/갯수로 줄여도 됨)
+    List<Candle> daily =
+        candleRepo.findByMarket_SymbolAndIntervalMinOrderByStartTimeAsc(symbol, DAILY);
+
+    if (daily.isEmpty()) {
+      return List.of();
+    }
+
+    // 2) KST 로컬데이트 기준으로 변환해 둠
+    List<Candle> normalized = daily;
+
+    // 3) 타임프레임별 집계
+    List<CandlePointResponse> out;
+    switch (tf) {
+      case D1 -> out = mapDaily(normalized);
+      case W1 -> out = aggregateWeekly(normalized);
+      case M1 -> out = aggregateMonthly(normalized, 1);
+      case M3 -> out = aggregateMonthly(normalized, 3);
+      case Y1 -> out = aggregateYearly(normalized);
+      default -> out = mapDaily(normalized);
+    }
+
+    // 4) 최신에서 limit개만 반환 (기본: 전체)
+    if (limit != null && limit > 0 && out.size() > limit) {
+      return out.subList(out.size() - limit, out.size());
+    }
+    return out;
+  }
+
+  private List<CandlePointResponse> mapDaily(List<Candle> daily) {
+    return daily.stream()
+        .map(
+            c ->
+                CandlePointResponse.builder()
+                    .startTime(toKst(c.getStartTime()))
+                    .endTime(toKst(c.getStartTime()).plusDays(1).minusSeconds(1))
+                    .open(c.getOpenPrice())
+                    .high(c.getHighPrice())
+                    .low(c.getLowPrice())
+                    .close(c.getClosePrice())
+                    .volume(c.getVolume())
+                    .build())
+        .toList();
+  }
+
+  /** ISO 주차(월요일 시작) 기준 집계 */
+  private List<CandlePointResponse> aggregateWeekly(List<Candle> daily) {
+    WeekFields wf = WeekFields.ISO; // 월요일 시작
+    Map<String, List<Candle>> grouped =
+        daily.stream()
+            .collect(
+                Collectors.groupingBy(
+                    c -> {
+                      LocalDate d = toKst(c.getStartTime()).toLocalDate();
+                      int y = d.get(wf.weekBasedYear());
+                      int w = d.get(wf.weekOfWeekBasedYear());
+                      return y + "-W" + w;
+                    },
+                    LinkedHashMap::new,
+                    Collectors.toList()));
+
+    List<CandlePointResponse> out = new ArrayList<>();
+    for (List<Candle> bucket : grouped.values()) {
+      out.add(mergeBucket(bucket));
+    }
+    return out;
+  }
+
+  /** monthSpan=1(월봉), 3(3개월봉) */
+  private List<CandlePointResponse> aggregateMonthly(List<Candle> daily, int monthSpan) {
+    Map<String, List<Candle>> grouped =
+        daily.stream()
+            .collect(
+                Collectors.groupingBy(
+                    c -> {
+                      LocalDate d = toKst(c.getStartTime()).toLocalDate();
+                      int spanIdx = (d.getMonthValue() - 1) / monthSpan; // 0~3
+                      int spanMonthStart = (spanIdx * monthSpan) + 1; // 1,4,7,10 (monthSpan=3일 때)
+                      YearMonth anchor = YearMonth.of(d.getYear(), spanMonthStart);
+                      return anchor.toString() + "/span" + monthSpan; // 예: 2025-01/span3
+                    },
+                    LinkedHashMap::new,
+                    Collectors.toList()));
+
+    List<CandlePointResponse> out = new ArrayList<>();
+    for (Map.Entry<String, List<Candle>> e : grouped.entrySet()) {
+      List<Candle> bucket = e.getValue();
+      // start/end 계산
+      LocalDateTime start =
+          toKst(bucket.get(0).getStartTime())
+              .withDayOfMonth(1)
+              .withHour(0)
+              .withMinute(0)
+              .withSecond(0)
+              .withNano(0);
+      LocalDateTime end = start.plusMonths(monthSpan).minusSeconds(1);
+      out.add(mergeBucket(bucket, start, end));
+    }
+    return out;
+  }
+
+  /** yaerSpan=1(년봉) */
+  private List<CandlePointResponse> aggregateYearly(List<Candle> daily) {
+    Map<Integer, List<Candle>> grouped =
+        daily.stream()
+            .collect(
+                Collectors.groupingBy(
+                    c -> {
+                      LocalDate d = toKst(c.getStartTime()).toLocalDate();
+                      return d.getYear(); // 연도별 그룹
+                    },
+                    LinkedHashMap::new,
+                    Collectors.toList()));
+
+    List<CandlePointResponse> out = new ArrayList<>();
+    for (Map.Entry<Integer, List<Candle>> e : grouped.entrySet()) {
+      int year = e.getKey();
+      List<Candle> bucket = e.getValue();
+      LocalDateTime start = LocalDateTime.of(year, 1, 1, 0, 0);
+      LocalDateTime end = start.plusYears(1).minusSeconds(1);
+      out.add(mergeBucket(bucket, start, end));
+    }
+    return out;
+  }
+
+  /** 버킷(연속 일봉들)을 하나의 캔들로 머지 */
+  private CandlePointResponse mergeBucket(List<Candle> bucket) {
+    bucket.sort(Comparator.comparing(Candle::getStartTime));
+    LocalDateTime s = toKst(bucket.get(0).getStartTime());
+    // endTime은 버킷 마지막 날의 23:59:59 로 표시
+    LocalDateTime e =
+        toKst(bucket.get(bucket.size() - 1).getStartTime())
+            .withHour(23)
+            .withMinute(59)
+            .withSecond(59);
+    return mergeBucket(bucket, s, e);
+  }
+
+  private CandlePointResponse mergeBucket(
+      List<Candle> bucket, LocalDateTime start, LocalDateTime end) {
+    bucket.sort(Comparator.comparing(Candle::getStartTime));
+    var open = bucket.get(0).getOpenPrice();
+    var close = bucket.get(bucket.size() - 1).getClosePrice();
+    var high = bucket.stream().map(Candle::getHighPrice).max(BigDecimal::compareTo).orElse(open);
+    var low = bucket.stream().map(Candle::getLowPrice).min(BigDecimal::compareTo).orElse(open);
+    var vol = bucket.stream().map(Candle::getVolume).reduce(BigDecimal.ZERO, BigDecimal::add);
+
+    return CandlePointResponse.builder()
+        .startTime(start)
+        .endTime(end)
+        .open(open)
+        .high(high)
+        .low(low)
+        .close(close)
+        .volume(vol)
+        .build();
+  }
+
+  private LocalDateTime toKst(LocalDateTime utcLike) {
+    // DB가 LocalDateTime(UTC 기준 저장 or KST 저장)이라면, 여기서는 “표시 기준”만 KST로 맞추는 용도
+    return ZonedDateTime.of(utcLike, ZoneId.systemDefault())
+        .withZoneSameInstant(KST)
+        .toLocalDateTime();
+  }
+}

--- a/src/main/java/com/hackathon/tomolow/domain/candle/service/CandleScheduler.java
+++ b/src/main/java/com/hackathon/tomolow/domain/candle/service/CandleScheduler.java
@@ -1,0 +1,28 @@
+package com.hackathon.tomolow.domain.candle.service;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import com.hackathon.tomolow.domain.market.entity.ExchangeType;
+import com.hackathon.tomolow.domain.market.entity.Market;
+import com.hackathon.tomolow.domain.market.repository.MarketRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CandleScheduler {
+
+  private final MarketRepository marketRepo;
+  private final CandleIngestService ingest;
+
+  // 매일 00:05 KST에 최근 5개만 동기화(업서트)
+  @Scheduled(cron = "0 5 0 * * *", zone = "Asia/Seoul")
+  public void syncDaily() throws Exception {
+    for (Market m : marketRepo.findAll()) {
+      if (m.getExchangeType() == ExchangeType.UPBIT) {
+        ingest.upsertDayCandles(m, 5);
+      }
+    }
+  }
+}

--- a/src/main/java/com/hackathon/tomolow/domain/candle/service/UpbitRestClient.java
+++ b/src/main/java/com/hackathon/tomolow/domain/candle/service/UpbitRestClient.java
@@ -1,0 +1,62 @@
+package com.hackathon.tomolow.domain.candle.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hackathon.tomolow.domain.candle.dto.UpbitDayCandle;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+/** ✅ Upbit REST API Client - 일봉(1D) 데이터 수집 - KRW-BTC, KRW-ETH 등 다양한 마켓 코드 지원 */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Tag(name = "Upbit REST Client", description = "업비트 일봉(1D) 데이터 조회용 클라이언트")
+public class UpbitRestClient {
+
+  private static final String BASE_URL = "https://api.upbit.com/v1/candles/days";
+  private final OkHttpClient httpClient = new OkHttpClient();
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  /**
+   * 📈 업비트 일봉 데이터 조회
+   *
+   * @param market 마켓 코드 (예: "KRW-BTC", "KRW-ETH")
+   * @param count 조회할 일수 (1~200)
+   * @return UpbitDayCandle 리스트
+   */
+  @Operation(
+      summary = "업비트 일봉 데이터 조회",
+      description = "Upbit REST API를 호출하여 특정 마켓의 일봉(1D) 데이터를 반환합니다.")
+  public List<UpbitDayCandle> getDayCandles(String market, int count) throws Exception {
+    String url = String.format("%s?market=%s&count=%d", BASE_URL, market, count);
+    log.info("Requesting Upbit Daily Candles → {}", url);
+
+    Request request = new Request.Builder().url(url).get().build();
+
+    try (Response response = httpClient.newCall(request).execute()) {
+      if (!response.isSuccessful()) {
+        throw new RuntimeException("Upbit API 요청 실패: " + response.code());
+      }
+
+      String body = response.body().string();
+      List<UpbitDayCandle> candles =
+          objectMapper.readValue(body, new TypeReference<List<UpbitDayCandle>>() {});
+
+      log.info("✅ Upbit 일봉 데이터 수신 완료 ({}개) market={}", candles.size(), market);
+      return candles;
+    } catch (Exception e) {
+      log.error("❌ Upbit API 요청 실패 (market={}): {}", market, e.getMessage());
+      throw e;
+    }
+  }
+}

--- a/src/main/java/com/hackathon/tomolow/domain/market/controller/MarketController.java
+++ b/src/main/java/com/hackathon/tomolow/domain/market/controller/MarketController.java
@@ -1,0 +1,78 @@
+package com.hackathon.tomolow.domain.market.controller;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.hackathon.tomolow.domain.market.dto.request.MarketCreateRequest;
+import com.hackathon.tomolow.domain.market.dto.request.MarketUpdateRequest;
+import com.hackathon.tomolow.domain.market.dto.response.MarketResponse;
+import com.hackathon.tomolow.domain.market.service.MarketService;
+import com.hackathon.tomolow.global.response.BaseResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Tag(name = "Market", description = "종목(Market) 관리 API (개발자용)")
+public class MarketController {
+
+  private final MarketService marketService;
+
+  @Operation(summary = "[개발자] 종목 생성", description = "새로운 종목을 등록합니다. (201 Created)")
+  @PostMapping("/dev/market")
+  public ResponseEntity<BaseResponse<MarketResponse>> create(
+      @Valid @RequestBody MarketCreateRequest request) {
+    MarketResponse response = marketService.create(request);
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(BaseResponse.success("종목 등록 성공", response));
+  }
+
+  @Operation(summary = "[개발자] 종목 전체 조회", description = "모든 종목을 조회합니다. (200 OK)")
+  @GetMapping("/dev/market")
+  public ResponseEntity<BaseResponse<List<MarketResponse>>> list() {
+    List<MarketResponse> list = marketService.findAll();
+    return ResponseEntity.ok(BaseResponse.success("종목 목록 조회 성공", list));
+  }
+
+  @Operation(summary = "[개발자] 특정 종목 조회", description = "symbol로 단건 조회합니다. (200 OK)")
+  @GetMapping("/dev/market/{symbol}")
+  public ResponseEntity<BaseResponse<MarketResponse>> get(
+      @Parameter(description = "종목 코드", example = "KRW-BTC") @PathVariable String symbol) {
+    MarketResponse res = marketService.findOne(symbol);
+    return ResponseEntity.ok(BaseResponse.success("종목 조회 성공", res));
+  }
+
+  @Operation(
+      summary = "[개발자] 종목 정보 수정",
+      description = "symbol 기준으로 이름, 이미지 URL, 자산/거래소를 수정합니다. (200 OK)")
+  @PatchMapping("/dev/market")
+  public ResponseEntity<BaseResponse<MarketResponse>> update(
+      @Valid @RequestBody MarketUpdateRequest request) {
+    MarketResponse response = marketService.update(request);
+    return ResponseEntity.ok(BaseResponse.success("종목 정보 수정", response));
+  }
+
+  @Operation(summary = "[개발자] 종목 삭제", description = "symbol로 해당 종목을 삭제합니다. (200 OK)")
+  @DeleteMapping("/dev/market/{symbol}")
+  public ResponseEntity<BaseResponse<String>> delete(
+      @Parameter(description = "종목 코드", example = "KRW-BTC") @PathVariable String symbol) {
+    marketService.delete(symbol);
+    return ResponseEntity.ok(BaseResponse.success("종목 삭제 완료"));
+  }
+}

--- a/src/main/java/com/hackathon/tomolow/domain/market/dto/request/MarketCreateRequest.java
+++ b/src/main/java/com/hackathon/tomolow/domain/market/dto/request/MarketCreateRequest.java
@@ -1,0 +1,40 @@
+package com.hackathon.tomolow.domain.market.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import com.hackathon.tomolow.domain.market.entity.AssetType;
+import com.hackathon.tomolow.domain.market.entity.ExchangeType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(title = "MarketCreateRequest", description = "종목 생성을 위한 요청")
+public class MarketCreateRequest {
+
+  @NotBlank
+  @Schema(description = "종목명", example = "비트코인")
+  private String name;
+
+  @NotBlank
+  @Schema(description = "심볼(유니크)", example = "KRW-BTC")
+  private String symbol;
+
+  @NotNull
+  @Schema(description = "자산 유형", example = "CRYPTO")
+  private AssetType assetType;
+
+  @NotNull
+  @Schema(description = "거래소", example = "UPBIT")
+  private ExchangeType exchangeType;
+
+  @Schema(description = "이미지 URL", example = "https://.../btc.png")
+  private String imgUrl;
+}

--- a/src/main/java/com/hackathon/tomolow/domain/market/dto/request/MarketUpdateRequest.java
+++ b/src/main/java/com/hackathon/tomolow/domain/market/dto/request/MarketUpdateRequest.java
@@ -1,0 +1,36 @@
+package com.hackathon.tomolow.domain.market.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+import com.hackathon.tomolow.domain.market.entity.AssetType;
+import com.hackathon.tomolow.domain.market.entity.ExchangeType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(title = "MarketUpdateRequest", description = "종목 수정을 위한 요청")
+public class MarketUpdateRequest {
+
+  @NotBlank
+  @Schema(description = "수정 대상 심볼", example = "KRW-BTC")
+  private String symbol;
+
+  @Schema(description = "새 종목명(옵션)", example = "비트코인")
+  private String newName;
+
+  @Schema(description = "새 이미지 URL(옵션)", example = "https://.../btc-v2.png")
+  private String newImgUrl;
+
+  @Schema(description = "새 자산 유형(옵션)", example = "CRYPTO")
+  private AssetType newAssetType;
+
+  @Schema(description = "새 거래소(옵션)", example = "UPBIT")
+  private ExchangeType newExchangeType;
+}

--- a/src/main/java/com/hackathon/tomolow/domain/market/dto/response/MarketResponse.java
+++ b/src/main/java/com/hackathon/tomolow/domain/market/dto/response/MarketResponse.java
@@ -1,0 +1,36 @@
+package com.hackathon.tomolow.domain.market.dto.response;
+
+import com.hackathon.tomolow.domain.market.entity.AssetType;
+import com.hackathon.tomolow.domain.market.entity.ExchangeType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(title = "MarketResponse", description = "종목 응답 DTO")
+public class MarketResponse {
+
+  @Schema(description = "종목 ID", example = "1")
+  private Long id;
+
+  @Schema(description = "종목명", example = "비트코인")
+  private String name;
+
+  @Schema(description = "심볼", example = "KRW-BTC")
+  private String symbol;
+
+  @Schema(description = "자산 유형", example = "CRYPTO")
+  private AssetType assetType;
+
+  @Schema(description = "거래소", example = "UPBIT")
+  private ExchangeType exchangeType;
+
+  @Schema(description = "이미지 URL")
+  private String imgUrl;
+}

--- a/src/main/java/com/hackathon/tomolow/domain/market/entity/Market.java
+++ b/src/main/java/com/hackathon/tomolow/domain/market/entity/Market.java
@@ -45,4 +45,21 @@ public class Market extends BaseTimeEntity {
 
   @Column(name = "img_url")
   private String imgUrl; // 주식 이미지 (nullable)
+
+  // set methods
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public void setImgUrl(String imgUrl) {
+    this.imgUrl = imgUrl;
+  }
+
+  public void setAssetType(AssetType assetType) {
+    this.assetType = assetType;
+  }
+
+  public void setExchangeType(ExchangeType exchangeType) {
+    this.exchangeType = exchangeType;
+  }
 }

--- a/src/main/java/com/hackathon/tomolow/domain/market/mapper/MarketMapper.java
+++ b/src/main/java/com/hackathon/tomolow/domain/market/mapper/MarketMapper.java
@@ -1,0 +1,21 @@
+package com.hackathon.tomolow.domain.market.mapper;
+
+import org.springframework.stereotype.Component;
+
+import com.hackathon.tomolow.domain.market.dto.response.MarketResponse;
+import com.hackathon.tomolow.domain.market.entity.Market;
+
+@Component
+public class MarketMapper {
+
+  public MarketResponse toResponse(Market m) {
+    return MarketResponse.builder()
+        .id(m.getId())
+        .name(m.getName())
+        .symbol(m.getSymbol())
+        .assetType(m.getAssetType())
+        .exchangeType(m.getExchangeType())
+        .imgUrl(m.getImgUrl())
+        .build();
+  }
+}

--- a/src/main/java/com/hackathon/tomolow/domain/market/repository/MarketRepository.java
+++ b/src/main/java/com/hackathon/tomolow/domain/market/repository/MarketRepository.java
@@ -1,7 +1,19 @@
 package com.hackathon.tomolow.domain.market.repository;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.hackathon.tomolow.domain.market.entity.ExchangeType;
 import com.hackathon.tomolow.domain.market.entity.Market;
 
-public interface MarketRepository extends JpaRepository<Market, Long> {}
+public interface MarketRepository extends JpaRepository<Market, Long> {
+
+  Optional<Market> findBySymbol(String symbol);
+
+  boolean existsBySymbol(String symbol);
+
+  // 업비트에 등록된 마켓만 가져오기
+  List<Market> findAllByExchangeType(ExchangeType exchangeType);
+}

--- a/src/main/java/com/hackathon/tomolow/domain/market/service/MarketService.java
+++ b/src/main/java/com/hackathon/tomolow/domain/market/service/MarketService.java
@@ -1,0 +1,97 @@
+package com.hackathon.tomolow.domain.market.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.hackathon.tomolow.domain.market.dto.request.MarketCreateRequest;
+import com.hackathon.tomolow.domain.market.dto.request.MarketUpdateRequest;
+import com.hackathon.tomolow.domain.market.dto.response.MarketResponse;
+import com.hackathon.tomolow.domain.market.entity.Market;
+import com.hackathon.tomolow.domain.market.exception.MarketErrorCode;
+import com.hackathon.tomolow.domain.market.mapper.MarketMapper;
+import com.hackathon.tomolow.domain.market.repository.MarketRepository;
+import com.hackathon.tomolow.global.exception.CustomException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MarketService {
+
+  private final MarketRepository marketRepository;
+  private final MarketMapper marketMapper;
+
+  @Transactional
+  public MarketResponse create(MarketCreateRequest req) {
+    if (marketRepository.existsBySymbol(req.getSymbol())) {
+      throw new CustomException(MarketErrorCode.MARKET_ALREADY_EXISTS);
+    }
+    Market saved =
+        marketRepository.save(
+            Market.builder()
+                .name(req.getName())
+                .symbol(req.getSymbol())
+                .assetType(req.getAssetType())
+                .exchangeType(req.getExchangeType())
+                .imgUrl(req.getImgUrl())
+                .build());
+    log.info("[Market 생성] symbol={}, name={}", saved.getSymbol(), saved.getName());
+    return marketMapper.toResponse(saved);
+  }
+
+  public List<MarketResponse> findAll() {
+    return marketRepository.findAll().stream().map(marketMapper::toResponse).toList();
+  }
+
+  public MarketResponse findOne(String symbol) {
+    Market market =
+        marketRepository
+            .findBySymbol(symbol)
+            .orElseThrow(() -> new CustomException(MarketErrorCode.MARKET_NOT_FOUND));
+    return marketMapper.toResponse(market);
+  }
+
+  @Transactional
+  public MarketResponse update(MarketUpdateRequest req) {
+    Market market =
+        marketRepository
+            .findBySymbol(req.getSymbol())
+            .orElseThrow(() -> new CustomException(MarketErrorCode.MARKET_NOT_FOUND));
+
+    if (req.getNewName() != null) {
+      market.setName(req.getNewName());
+    }
+    if (req.getNewImgUrl() != null) {
+      market.setImgUrl(req.getNewImgUrl());
+    }
+    if (req.getNewAssetType() != null) {
+      market.setAssetType(req.getNewAssetType());
+    }
+    if (req.getNewExchangeType() != null) {
+      market.setExchangeType(req.getNewExchangeType());
+    }
+
+    log.info(
+        "[Market 수정] symbol={}, name={}, assetType={}, exchangeType={}",
+        market.getSymbol(),
+        market.getName(),
+        market.getAssetType(),
+        market.getExchangeType());
+
+    return marketMapper.toResponse(market);
+  }
+
+  @Transactional
+  public void delete(String symbol) {
+    Market market =
+        marketRepository
+            .findBySymbol(symbol)
+            .orElseThrow(() -> new CustomException(MarketErrorCode.MARKET_NOT_FOUND));
+    marketRepository.delete(market);
+    log.info("[Market 삭제] symbol={}", symbol);
+  }
+}

--- a/src/main/java/com/hackathon/tomolow/domain/ticker/dto/TickerMessage.java
+++ b/src/main/java/com/hackathon/tomolow/domain/ticker/dto/TickerMessage.java
@@ -15,9 +15,14 @@ import lombok.Setter;
 @NoArgsConstructor
 public class TickerMessage {
 
-  private String market; // e.g. BTC-KRW (ex.비트코인)
+  private String market; // 예: KRW-BTC
+  private String marketName; // 예: 비트코인
+
   private BigDecimal tradePrice; // 현재가
-  private BigDecimal changeRate; // 전일대비 등락률 (예: 0.0123 = +1.23%)
-  private BigDecimal accVolume; // 누적 거래량(24h)
-  private long tradeTimestamp; // 틱 시각 (ms)
+  private BigDecimal changeRate; // 전일대비 등락률 (0.0123 = +1.23%)
+  private BigDecimal changePrice; // 전일대비 등락 원
+  private BigDecimal prevClose; // 전일 종가
+
+  private BigDecimal accVolume; // 누적 거래량(24h) (수량)
+  private long tradeTimestamp; // 틱 시각(ms)
 }

--- a/src/main/java/com/hackathon/tomolow/domain/user/controller/UserController.java
+++ b/src/main/java/com/hackathon/tomolow/domain/user/controller/UserController.java
@@ -1,0 +1,78 @@
+package com.hackathon.tomolow.domain.user.controller;
+
+import java.math.BigDecimal;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.hackathon.tomolow.domain.user.dto.response.TopUpResponse;
+import com.hackathon.tomolow.domain.user.entity.User;
+import com.hackathon.tomolow.domain.user.service.UserService;
+import com.hackathon.tomolow.global.response.BaseResponse;
+import com.hackathon.tomolow.global.security.CustomUserDetails;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+@Tag(name = "User", description = "유저 관련 API")
+public class UserController {
+
+  private final UserService userService;
+
+  @Operation(summary = "광고 보상 충전", description = "광고 시청 시 500,000원 지급")
+  @PostMapping("/mypage/cash/ad")
+  public ResponseEntity<BaseResponse<TopUpResponse>> topUpAd(
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+    User user = userDetails.getUser();
+    TopUpResponse res = userService.topUpFixed(user, new BigDecimal("500000"));
+    return ResponseEntity.ok(BaseResponse.success("광고 보상 충전 완료", res));
+  }
+
+  @Operation(summary = "+1,000만원 충전", description = "버튼 클릭 시 1,000만원 충전")
+  @PostMapping("/mypage/cash/10m")
+  public ResponseEntity<BaseResponse<TopUpResponse>> topUp10m(
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+    User user = userDetails.getUser();
+    TopUpResponse res = userService.topUpFixed(user, new BigDecimal("10000000"));
+    return ResponseEntity.ok(BaseResponse.success("+1,000만원 충전 완료", res));
+  }
+
+  @Operation(summary = "+3,000만원 충전", description = "버튼 클릭 시 3,000만원 충전")
+  @PostMapping("/mypage/cash/30m")
+  public ResponseEntity<BaseResponse<TopUpResponse>> topUp30m(
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+    User user = userDetails.getUser();
+    TopUpResponse res = userService.topUpFixed(user, new BigDecimal("30000000"));
+    return ResponseEntity.ok(BaseResponse.success("+3,000만원 충전 완료", res));
+  }
+
+  @Operation(summary = "+5,000만원 충전", description = "버튼 클릭 시 5,000만원 충전")
+  @PostMapping("/mypage/cash/50m")
+  public ResponseEntity<BaseResponse<TopUpResponse>> topUp50m(
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+    User user = userDetails.getUser();
+    TopUpResponse res = userService.topUpFixed(user, new BigDecimal("50000000"));
+    return ResponseEntity.ok(BaseResponse.success("+5,000만원 충전 완료", res));
+  }
+
+  @Operation(summary = "+1억원 충전", description = "버튼 클릭 시 1억원 충전")
+  @PostMapping("/mypage/cash/100m")
+  public ResponseEntity<BaseResponse<TopUpResponse>> topUp100m(
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+    User user = userDetails.getUser();
+    TopUpResponse res = userService.topUpFixed(user, new BigDecimal("100000000"));
+    return ResponseEntity.ok(BaseResponse.success("+1억원 충전 완료", res));
+  }
+}

--- a/src/main/java/com/hackathon/tomolow/domain/user/dto/response/TopUpResponse.java
+++ b/src/main/java/com/hackathon/tomolow/domain/user/dto/response/TopUpResponse.java
@@ -1,0 +1,27 @@
+package com.hackathon.tomolow.domain.user.dto.response;
+
+import java.math.BigDecimal;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 💰 머니 충전 결과 응답 DTO - 마이페이지의 자산 그래프 및 현금/투자자산 영역 갱신용 */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(title = "TopUpResponse", description = "머니 충전 후 최신 자산 상태 응답 DTO")
+public class TopUpResponse {
+
+  @Schema(description = "충전 후 현금 잔액", example = "12500000.00")
+  private BigDecimal cashBalance;
+
+  @Schema(description = "현재 투자 자산 잔액", example = "2333354.00")
+  private BigDecimal investmentBalance;
+
+  @Schema(description = "전체 자산 (현금 + 투자)", example = "14833354.00")
+  private BigDecimal totalAsset;
+}

--- a/src/main/java/com/hackathon/tomolow/domain/user/service/UserService.java
+++ b/src/main/java/com/hackathon/tomolow/domain/user/service/UserService.java
@@ -1,0 +1,35 @@
+package com.hackathon.tomolow.domain.user.service;
+
+import java.math.BigDecimal;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.hackathon.tomolow.domain.user.dto.response.TopUpResponse;
+import com.hackathon.tomolow.domain.user.entity.User;
+import com.hackathon.tomolow.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserService {
+
+  private final UserRepository userRepository;
+
+  @Transactional
+  public TopUpResponse topUpFixed(User user, BigDecimal amount) {
+    user.addCashBalance(amount);
+
+    userRepository.save(user);
+
+    BigDecimal total = user.getCashBalance().add(user.getInvestmentBalance());
+    return TopUpResponse.builder()
+        .cashBalance(user.getCashBalance())
+        .investmentBalance(user.getInvestmentBalance())
+        .totalAsset(total)
+        .build();
+  }
+}

--- a/src/main/java/com/hackathon/tomolow/global/config/SecurityConfig.java
+++ b/src/main/java/com/hackathon/tomolow/global/config/SecurityConfig.java
@@ -55,6 +55,9 @@ public class SecurityConfig {
                     // 인증 없이 허용할 경로
                     .requestMatchers("/api/auth/**", "/api/ticker/**")
                     .permitAll()
+                    // 개발자 전용 API — 지금은 임시로 공개
+                    .requestMatchers("/api/dev/**")
+                    .permitAll()
                     // 정적 리소스 (공통 위치: /static, /public, /resources, /META-INF/resources)
                     .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
                     .permitAll()

--- a/src/main/resources/static/test.html
+++ b/src/main/resources/static/test.html
@@ -5,7 +5,7 @@
   <title>STOMP 실시간 시세 테스트</title>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
 
-  <!-- 정적 리소스: /src/main/resources/static/js/...  -->
+  <!-- 정적 리소스: /src/main/resources/static/js/... -->
   <script src="/js/sockjs.min.js"></script>
   <script src="/js/stomp.umd.min.js"></script>
 
@@ -142,6 +142,12 @@
     <select id="market">
       <option value="KRW-BTC">KRW-BTC (비트코인)</option>
       <option value="KRW-ETH">KRW-ETH (이더리움)</option>
+      <option value="KRW-XRP">KRW-XRP (리플)</option>
+      <option value="KRW-ADA">KRW-ADA (에이다)</option>
+      <option value="KRW-SOL">KRW-SOL (솔라나)</option>
+      <option value="KRW-DOT">KRW-DOT (폴카닷)</option>
+      <option value="KRW-DOGE">KRW-DOGE (도지코인)</option>
+      <option value="KRW-LINK">KRW-LINK (체인링크)</option>
     </select>
 
     <button id="btnConnectWs">Connect (Native WS)</button>
@@ -158,6 +164,7 @@
       <div class="name" id="name">비트코인 <span class="code" id="code">(KRW-BTC)</span></div>
       <div id="price" class="price">-</div>
       <div id="change" class="sub">전일대비 -</div>
+      <div id="prev" class="sub">전일 종가: -</div>
       <div id="vol" class="sub">누적 거래량(24h): -</div>
       <div id="time" class="time"></div>
     </div>
@@ -168,7 +175,7 @@
 </div>
 
 <script>
-  // ====== 환경별 자동 URL (배포/로컬 공통) ======
+  // ====== 환경별 자동 URL ======
   const WS_NATIVE_URL = (location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host
       + '/ws';
   const SOCKJS_FULL_URL = location.origin + '/ws-sockjs';
@@ -189,19 +196,19 @@
     currentTransport = t;
     el('transport').textContent = 'transport: ' + t;
   };
+
   const fmtPrice = (n) => Number(n ?? 0).toLocaleString('ko-KR');
-  const fmtPct = (n) => `${n >= 0 ? '+' : ''}${(Number(n) * 100).toFixed(2)}%`;
+  const fmtPct = (n) => `${(Number(n) >= 0 ? '+' : '')}${(Number(n) * 100).toFixed(2)}%`;
+  const fmtWon = (n) => `${(Number(n) >= 0 ? '+' : '')}${Number(n ?? 0).toLocaleString('ko-KR')}원`;
   const fmtVol = (n) => Number(n ?? 0).toFixed(4);
 
-  // ====== STOMP/SockJS 전역 ======
+  // ====== STOMP/SockJS ======
   const STOMP = window.StompJs || window.Stomp;
   const SockJSGlobal = window.SockJS || window.sockjs;
-
   if (!STOMP) {
     log("❌ STOMP 라이브러리를 불러오지 못했습니다. /js/stomp.umd.min.js 확인");
   }
 
-  // ====== 클라이언트 팩토리 ======
   function createClientNative() {
     return new STOMP.Client({
       brokerURL: WS_NATIVE_URL,
@@ -216,9 +223,9 @@
         setStatus(false);
         log('🔻 DISCONNECTED');
       },
-      onStompError: (frame) => {
-        log('❌ STOMP ERROR: ' + (frame.headers?.message || ''));
-        log(frame.body || '');
+      onStompError: (f) => {
+        log('❌ STOMP ERROR: ' + (f.headers?.message || ''));
+        log(f.body || '');
       },
       onWebSocketError: (e) => log('❌ WS ERROR: ' + (e?.message || e)),
     });
@@ -242,15 +249,14 @@
         setStatus(false);
         log('🔻 DISCONNECTED');
       },
-      onStompError: (frame) => {
-        log('❌ STOMP ERROR: ' + (frame.headers?.message || ''));
-        log(frame.body || '');
+      onStompError: (f) => {
+        log('❌ STOMP ERROR: ' + (f.headers?.message || ''));
+        log(f.body || '');
       },
       onWebSocketError: (e) => log('❌ WS ERROR: ' + (e?.message || e)),
     });
   }
 
-  // ====== 액션 ======
   function connectNative() {
     if (!STOMP) {
       return;
@@ -283,22 +289,34 @@
       currentSub = null;
     }
 
-    // 카드 초기화
-    el('name').innerHTML = (market === 'KRW-ETH' ? '이더리움' : '비트코인')
-        + ' <span class="code" id="code">(' + market + ')</span>';
+    // UI 초기화 (이름은 서버 값 오기 전 임시값)
+    const fallbackName = market === 'KRW-ETH' ? '이더리움' : (market === 'KRW-BTC' ? '비트코인' : market);
+    el('name').innerHTML = fallbackName + ' <span class="code" id="code">(' + market + ')</span>';
     el('price').textContent = '-';
     el('change').textContent = '전일대비 -';
+    el('change').className = 'sub';
+    el('prev').textContent = '전일 종가: -';
     el('vol').textContent = '누적 거래량(24h): -';
     el('time').textContent = '';
 
     currentSub = client.subscribe('/topic/ticker/' + market, (msg) => {
       try {
         const t = JSON.parse(msg.body);
+        // 새 필드들 반영: marketName, changePrice, prevClose
+        const name = t.marketName || fallbackName;
+        el('name').innerHTML = `${name} <span class="code" id="code">(${t.market
+        || market})</span>`;
+
         el('price').textContent = fmtPrice(t.tradePrice) + ' 원';
-        const up = (t.changeRate ?? 0) >= 0;
-        el('change').textContent = '전일대비 ' + fmtPct(t.changeRate);
-        el('change').className = 'sub ' + (up ? 'up' : 'down');
-        el('price').className = 'price ' + (up ? 'up' : 'down');
+        const isUp = Number(t.changeRate ?? 0) >= 0;
+        el('price').className = 'price ' + (isUp ? 'up' : 'down');
+
+        // 전일대비: +8,700원 (+10.50%)
+        const changeText = `${fmtWon(t.changePrice)} (${fmtPct(t.changeRate)})`;
+        el('change').textContent = '전일대비 ' + changeText;
+        el('change').className = 'sub ' + (isUp ? 'up' : 'down');
+
+        el('prev').textContent = '전일 종가: ' + fmtPrice(t.prevClose) + ' 원';
         el('vol').textContent = '누적 거래량(24h): ' + fmtVol(t.accVolume);
         el('time').textContent = new Date(t.tradeTimestamp).toLocaleTimeString();
       } catch (e) {
@@ -309,11 +327,12 @@
     log('🧷 SUBSCRIBED: /topic/ticker/' + market + ' (' + currentTransport + ')');
   }
 
-  // ====== 버튼 바인딩 ======
-  el('btnConnectWs').onclick = connectNative;
-  el('btnConnectSock').onclick = connectSockJS;
-  el('btnSubscribe').onclick = () => subscribeMarket(el('market').value);
-  el('btnDisconnect').onclick = () => client?.deactivate();
+  // 버튼 바인딩
+  document.getElementById('btnConnectWs').onclick = connectNative;
+  document.getElementById('btnConnectSock').onclick = connectSockJS;
+  document.getElementById('btnSubscribe').onclick = () => subscribeMarket(
+      document.getElementById('market').value);
+  document.getElementById('btnDisconnect').onclick = () => client?.deactivate();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## #️⃣ 연관 이슈

> #17 

## 📝 작업 내용

- [ ] 개발자용 market CRUD api
- [ ] 각 종목들의 1일봉 candle 데이터 자동으로 db에 적재되도록 scheduler
- [ ] 1D, 1W, 1M, 3M, 1Y 별 candle 데이터 조회 api
- [ ] user에 머니 충전 api 추가
- [ ] 실시간 종목 데이터 불러오기에서 ui에 있는 데이터들 모두 불러오도록 수정

## 💬 리뷰 요구사항

- [ ] ex) ~부분은 무엇으로 통일하는 게 좋을가요?
- [ ] 요구사항 2

## 📸 스크린샷
