### PR TITLE
✨ 보유중인 market과 그로 인한 투자 손익원/율 실시간 계산해 보여주는 기능 개발

### DIFF
--- a/src/main/java/com/hackathon/tomolow/domain/portfilio/controller/PortfolioWsController.java
+++ b/src/main/java/com/hackathon/tomolow/domain/portfilio/controller/PortfolioWsController.java
@@ -1,0 +1,36 @@
+package com.hackathon.tomolow.domain.portfilio.controller;
+
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Controller;
+
+import com.hackathon.tomolow.domain.portfilio.service.PortfolioPnlService;
+import com.hackathon.tomolow.domain.portfilio.service.PortfolioRedisService;
+
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+public class PortfolioWsController {
+
+  private final PortfolioRedisService portfolioRedisService;
+  private final PortfolioPnlService portfolioPnlService; // ✅ 추가
+
+  // 클라이언트: /app/portfolio/online 로 userId 전송
+  @MessageMapping("/portfolio/online")
+  public void online(@Payload Long userId) {
+    if (userId == null) {
+      return;
+    }
+    portfolioRedisService.online(userId);
+    portfolioPnlService.onOnline(userId); // ✅ 인덱스 재작성 + baseline 저장 + 즉시 1회 푸시
+  }
+
+  @MessageMapping("/portfolio/offline")
+  public void offline(@Payload Long userId) {
+    if (userId == null) {
+      return;
+    }
+    portfolioRedisService.offline(userId);
+  }
+}

--- a/src/main/java/com/hackathon/tomolow/domain/portfilio/dto/PortfolioPnlMessage.java
+++ b/src/main/java/com/hackathon/tomolow/domain/portfilio/dto/PortfolioPnlMessage.java
@@ -1,0 +1,19 @@
+package com.hackathon.tomolow.domain.portfilio.dto;
+
+import java.math.BigDecimal;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PortfolioPnlMessage {
+
+  private BigDecimal totalPnlAmount; // 총 손익(원)
+  private BigDecimal totalPnlRate; // 총 손익률(가중)
+  private long ts; // 서버 계산 시각(ms)
+}

--- a/src/main/java/com/hackathon/tomolow/domain/portfilio/service/PortfolioPnlService.java
+++ b/src/main/java/com/hackathon/tomolow/domain/portfilio/service/PortfolioPnlService.java
@@ -1,0 +1,144 @@
+package com.hackathon.tomolow.domain.portfilio.service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.hackathon.tomolow.domain.portfilio.dto.PortfolioPnlMessage;
+import com.hackathon.tomolow.domain.ticker.service.PriceQueryService;
+import com.hackathon.tomolow.domain.user.entity.User;
+import com.hackathon.tomolow.domain.user.repository.UserRepository;
+import com.hackathon.tomolow.domain.userMarketHolding.entity.UserMarketHolding;
+import com.hackathon.tomolow.domain.userMarketHolding.repository.UserMarketHoldingRepository;
+import com.hackathon.tomolow.global.redis.RedisUtil;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PortfolioPnlService {
+
+  private final RedisUtil redisUtil; // 인덱스 재작성 때만 사용
+  private final PortfolioRedisService pr; // ✅ 키 관리는 이 서비스 것만 사용
+  private final UserRepository userRepository;
+  private final UserMarketHoldingRepository holdingRepo;
+  private final PriceQueryService priceQueryService;
+  private final SimpMessagingTemplate messaging;
+
+  /** 온라인 된 직후 호출: 현재 보유 인덱스를 최신화하고, 절대 PnL을 baseline 으로 저장 + 즉시 1회 푸시 */
+  @Transactional(readOnly = true)
+  public void onOnline(long userId) {
+    reindexUserHoldings(userId); // 보유 심볼 인덱스 최신화
+    pushPnlAndSeedBaseline(userId); // 절대 PnL 계산 → baseline 저장 + 즉시 푸시
+  }
+
+  /** 사용자의 보유 심볼 인덱스를 Redis 세트로 재작성 (체결 이후/온라인 등록 시 호출) */
+  @Transactional(readOnly = true)
+  public void reindexUserHoldings(long userId) {
+    var t = redisUtil.getTemplate();
+
+    // 기존 인덱스 제거
+    Set<String> old = t.opsForSet().members("holdings:user:" + userId);
+    if (old != null) {
+      for (String s : old) {
+        // ✅ 실제 운용 키는 holders:{symbol}
+        t.opsForSet().remove("holders:" + s, String.valueOf(userId));
+      }
+      t.delete("holdings:user:" + userId);
+    }
+
+    User user = userRepository.findById(userId).orElse(null);
+    if (user == null) {
+      return;
+    }
+
+    List<UserMarketHolding> hs = holdingRepo.findAllByUser(user);
+    Set<String> symbols =
+        hs.stream()
+            .filter(h -> h.getQuantity() != null && h.getQuantity() > 0)
+            .map(h -> h.getMarket().getSymbol())
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+
+    // ✅ 양방향 인덱스 세팅(표면 키는 유지, 실제 보유자 세트는 holders:{symbol})
+    for (String s : symbols) {
+      t.opsForSet().add("holdings:user:" + userId, s);
+      pr.addHolder(s, userId); // holders:{symbol} 세트
+    }
+  }
+
+  /** 틱이 특정 심볼로 들어왔을 때, 그 심볼을 보유하고 '온라인'인 유저만 추려서 푸시 */
+  @Transactional(readOnly = true)
+  public void pushPnlForSymbol(String symbol) {
+    // ✅ 실제 보유자 세트 사용
+    Set<String> holders = pr.getHolders(symbol);
+    if (holders.isEmpty()) {
+      return;
+    }
+
+    // ✅ 실제 온라인 세트 사용
+    Set<String> online = pr.getOnlineUsers();
+    if (online.isEmpty()) {
+      return;
+    }
+
+    for (String uidStr : holders) {
+      if (!online.contains(uidStr)) {
+        continue;
+      }
+      long userId = Long.parseLong(uidStr);
+      pushPnlAndSeedBaseline(userId); // 절대 PnL 계산해 푸시(기존 baseline은 그대로 두어도 무방)
+    }
+  }
+
+  /** 단일 사용자에 대해 '절대' 총손익/손익률 계산 → baseline 저장(+즉시 푸시) */
+  @Transactional(readOnly = true)
+  public void pushPnlAndSeedBaseline(long userId) {
+    User user = userRepository.findById(userId).orElse(null);
+    if (user == null) {
+      return;
+    }
+
+    List<UserMarketHolding> holdings = holdingRepo.findAllByUser(user);
+
+    BigDecimal totalPnl = BigDecimal.ZERO;
+    BigDecimal invest = user.getInvestmentBalance(); // 매입 원금(고정)
+
+    for (UserMarketHolding h : holdings) {
+      if (h.getQuantity() == null || h.getQuantity() <= 0) {
+        continue;
+      }
+
+      String symbol = h.getMarket().getSymbol();
+      BigDecimal cur = priceQueryService.getLastTradePriceOrThrow(symbol);
+
+      BigDecimal qty = BigDecimal.valueOf(h.getQuantity());
+      BigDecimal inv = h.getAvgPrice().multiply(qty);
+      BigDecimal now = cur.multiply(qty);
+
+      totalPnl = totalPnl.add(now.subtract(inv));
+    }
+
+    BigDecimal rate =
+        invest.signum() == 0 ? BigDecimal.ZERO : totalPnl.divide(invest, 4, RoundingMode.HALF_UP);
+
+    // ✅ baseline 세팅: 현재 절대 PnL을 pnlKey 에 저장(증분 누적의 시작점)
+    pr.resetPnl(userId);
+    pr.incrPnl(userId, totalPnl.doubleValue());
+
+    // 즉시 1회 푸시
+    messaging.convertAndSend(
+        "/topic/portfolio/" + userId,
+        PortfolioPnlMessage.builder()
+            .totalPnlAmount(totalPnl)
+            .totalPnlRate(rate)
+            .ts(System.currentTimeMillis())
+            .build());
+  }
+}

--- a/src/main/java/com/hackathon/tomolow/domain/portfilio/service/PortfolioRedisService.java
+++ b/src/main/java/com/hackathon/tomolow/domain/portfilio/service/PortfolioRedisService.java
@@ -1,0 +1,104 @@
+package com.hackathon.tomolow.domain.portfilio.service;
+
+import java.math.BigDecimal;
+import java.util.Set;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PortfolioRedisService {
+
+  private final StringRedisTemplate redis;
+
+  private String holdersKey(String symbol) {
+    return "holders:" + symbol;
+  }
+
+  private String posKey(Long userId, String symbol) {
+    return "pos:" + userId + ":" + symbol;
+  }
+
+  private String pnlKey(Long userId) {
+    return "portfolio:pnl:" + userId;
+  }
+
+  private String onlineKey() {
+    return "ws:online";
+  }
+
+  private String prevPriceKey(String symbol) {
+    return "prev_price:" + symbol;
+  }
+
+  // ===== 보유자 세트 =====
+  public void addHolder(String symbol, Long userId) {
+    redis.opsForSet().add(holdersKey(symbol), String.valueOf(userId));
+  }
+
+  public void removeHolder(String symbol, Long userId) {
+    redis.opsForSet().remove(holdersKey(symbol), String.valueOf(userId));
+  }
+
+  public Set<String> getHolders(String symbol) {
+    var s = redis.opsForSet().members(holdersKey(symbol));
+    return (s == null) ? Set.of() : s;
+  }
+
+  // ===== 포지션 미러 =====
+  public void setPosition(Long userId, String symbol, long qty, BigDecimal avg) {
+    var key = posKey(userId, symbol);
+    redis.opsForHash().put(key, "qty", String.valueOf(qty));
+    redis.opsForHash().put(key, "avg", avg.toPlainString());
+  }
+
+  public long getQty(Long userId, String symbol) {
+    var v = (String) redis.opsForHash().get(posKey(userId, symbol), "qty");
+    return (v == null) ? 0L : Long.parseLong(v);
+  }
+
+  public void deletePosition(Long userId, String symbol) {
+    redis.delete(posKey(userId, symbol));
+  }
+
+  // ===== PnL 누적 =====
+  public void incrPnl(Long userId, double delta) {
+    redis.opsForValue().increment(pnlKey(userId), delta);
+  }
+
+  public double getPnl(Long userId) {
+    var v = redis.opsForValue().get(pnlKey(userId));
+    return (v == null) ? 0.0 : Double.parseDouble(v);
+  }
+
+  public void resetPnl(Long userId) {
+    redis.delete(pnlKey(userId));
+  }
+
+  // ===== 온라인 유저 =====
+  public void online(Long userId) {
+    redis.opsForSet().add(onlineKey(), String.valueOf(userId));
+  }
+
+  public void offline(Long userId) {
+    redis.opsForSet().remove(onlineKey(), String.valueOf(userId));
+  }
+
+  public Set<String> getOnlineUsers() {
+    var s = redis.opsForSet().members(onlineKey());
+    return (s == null) ? Set.of() : s;
+  }
+
+  // ===== prev price =====
+  public BigDecimal getPrevPrice(String symbol) {
+    var v = redis.opsForValue().get(prevPriceKey(symbol));
+    return (v == null) ? null : new BigDecimal(v);
+  }
+
+  public void setPrevPrice(String symbol, BigDecimal price) {
+    redis.opsForValue().set(prevPriceKey(symbol), price.toPlainString());
+  }
+}

--- a/src/main/java/com/hackathon/tomolow/domain/ticker/service/PriceTickDispatcher.java
+++ b/src/main/java/com/hackathon/tomolow/domain/ticker/service/PriceTickDispatcher.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.hackathon.tomolow.domain.market.repository.MarketRepository;
+import com.hackathon.tomolow.domain.portfilio.service.PortfolioPnlService;
 import com.hackathon.tomolow.domain.transaction.service.MatchService;
 
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ public class PriceTickDispatcher {
   private final ConcurrentMap<String, Semaphore> running = new ConcurrentHashMap<>();
   private final ExecutorService pool =
       Executors.newFixedThreadPool(Math.max(2, Runtime.getRuntime().availableProcessors() / 2));
+  private final PortfolioPnlService portfolioPnlService;
 
   public void onTick(String symbol, BigDecimal price) {
     lastPrice.put(symbol, price);
@@ -43,6 +45,8 @@ public class PriceTickDispatcher {
             if (p != null) {
               // 👇 Redis 오더북 기반 매칭 (시장가 기준)
               matchService.matchByMarketPrice(loadMarketIdBySymbol(symbol), p);
+              // ✅ 신규: 이 심볼 보유 + 온라인 유저에게 총손익 푸시
+              portfolioPnlService.pushPnlForSymbol(symbol);
             }
           } finally {
             sem.release();

--- a/src/main/java/com/hackathon/tomolow/domain/ticker/service/UpbitTickerService.java
+++ b/src/main/java/com/hackathon/tomolow/domain/ticker/service/UpbitTickerService.java
@@ -43,6 +43,7 @@ public class UpbitTickerService {
   private final MarketRepository marketRepository;
 
   private final PriceTickDispatcher tickDispatcher; // 추가: 틱을 매칭기로 넘겨줄 컴포넌트
+  // private final PortfolioIncrementService portfolioIncrementService; // 추가: 홈화면 포트폴리오 증분 누적
 
   // 심볼→이름 캐시
   private final Map<String, String> nameCache = new ConcurrentHashMap<>();
@@ -194,6 +195,9 @@ public class UpbitTickerService {
 
       // ✅ 틱이 온 심볼만 매칭 트리거(논블로킹)
       tickDispatcher.onTick(symbol, tradePrice);
+
+      // ✅ (추가) 포트폴리오 증분 누적 -> 스케줄러 삭제하면서, 증분로직 삭제, 증분 메서드 삭제.
+      // portfolioIncrementService.onTick(symbol, tradePrice);
 
     } catch (Exception e) {
       log.warn("Ticker parse/broadcast error: {}", e.getMessage());

--- a/src/main/java/com/hackathon/tomolow/domain/userMarketHolding/controller/UserMarketHoldingController.java
+++ b/src/main/java/com/hackathon/tomolow/domain/userMarketHolding/controller/UserMarketHoldingController.java
@@ -1,0 +1,31 @@
+package com.hackathon.tomolow.domain.userMarketHolding.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.hackathon.tomolow.domain.userMarketHolding.dto.HoldingsResponse;
+import com.hackathon.tomolow.domain.userMarketHolding.service.HoldingQueryService;
+import com.hackathon.tomolow.global.response.BaseResponse;
+import com.hackathon.tomolow.global.security.CustomUserDetails;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class UserMarketHoldingController {
+
+  private final HoldingQueryService holdingQueryService;
+
+  @GetMapping("/mypage/holdings/my")
+  @Operation(summary = "내 보유 종목 + 총 손익 조회(실시간 가격 반영)")
+  public ResponseEntity<BaseResponse<HoldingsResponse>> myHoldings(
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    var body = holdingQueryService.getMyHoldings(userDetails.getUser());
+    return ResponseEntity.ok(BaseResponse.success("OK", body));
+  }
+}

--- a/src/main/java/com/hackathon/tomolow/domain/userMarketHolding/dto/HoldingItemResponse.java
+++ b/src/main/java/com/hackathon/tomolow/domain/userMarketHolding/dto/HoldingItemResponse.java
@@ -1,0 +1,25 @@
+package com.hackathon.tomolow.domain.userMarketHolding.dto;
+
+import java.math.BigDecimal;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class HoldingItemResponse {
+
+  private Long marketId;
+  private String symbol; // KRW-BTC
+  private String name; // 비트코인
+  private String imageUrl; // 종목 이미지(없으면 null)
+  private long quantity; // 보유수량
+  private BigDecimal avgPrice; // 평균단가
+  private BigDecimal currentPrice; // 현재가(레디스)
+  private BigDecimal pnlAmount; // 손익원 = (현재가-평단)*수량
+  private BigDecimal pnlRate; // 손익률 = 손익원 / (평단*수량)
+}

--- a/src/main/java/com/hackathon/tomolow/domain/userMarketHolding/dto/HoldingsResponse.java
+++ b/src/main/java/com/hackathon/tomolow/domain/userMarketHolding/dto/HoldingsResponse.java
@@ -1,0 +1,18 @@
+package com.hackathon.tomolow.domain.userMarketHolding.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class HoldingsResponse {
+
+  private List<HoldingItemResponse> items;
+  private PortfolioSummaryResponse portfolio;
+}

--- a/src/main/java/com/hackathon/tomolow/domain/userMarketHolding/dto/PortfolioSummaryResponse.java
+++ b/src/main/java/com/hackathon/tomolow/domain/userMarketHolding/dto/PortfolioSummaryResponse.java
@@ -1,0 +1,21 @@
+package com.hackathon.tomolow.domain.userMarketHolding.dto;
+
+import java.math.BigDecimal;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PortfolioSummaryResponse {
+
+  private BigDecimal totalInvestment; // 투자자산
+  private BigDecimal cashBalance; // 현금자산
+  private BigDecimal totalCurrentValue; // 전체자산
+  private BigDecimal totalPnlAmount; // 총손익원 (실시간 데이터)
+  private BigDecimal totalPnlRate; // 총손익률 = 총손익원 / 총매입금액 (실시간 데이터)
+}

--- a/src/main/java/com/hackathon/tomolow/domain/userMarketHolding/repository/UserMarketHoldingRepository.java
+++ b/src/main/java/com/hackathon/tomolow/domain/userMarketHolding/repository/UserMarketHoldingRepository.java
@@ -1,5 +1,6 @@
 package com.hackathon.tomolow.domain.userMarketHolding.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,7 @@ import com.hackathon.tomolow.domain.userMarketHolding.entity.UserMarketHolding;
 public interface UserMarketHoldingRepository extends JpaRepository<UserMarketHolding, Long> {
 
   Optional<UserMarketHolding> findByUserAndMarket(User user, Market market);
+
+  // ✅ 내 보유 종목 전체 조회용
+  List<UserMarketHolding> findAllByUser(User user);
 }

--- a/src/main/java/com/hackathon/tomolow/domain/userMarketHolding/service/HoldingQueryService.java
+++ b/src/main/java/com/hackathon/tomolow/domain/userMarketHolding/service/HoldingQueryService.java
@@ -1,0 +1,100 @@
+package com.hackathon.tomolow.domain.userMarketHolding.service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.hackathon.tomolow.domain.market.entity.Market;
+import com.hackathon.tomolow.domain.ticker.service.PriceQueryService;
+import com.hackathon.tomolow.domain.user.entity.User;
+import com.hackathon.tomolow.domain.userMarketHolding.dto.HoldingItemResponse;
+import com.hackathon.tomolow.domain.userMarketHolding.dto.HoldingsResponse;
+import com.hackathon.tomolow.domain.userMarketHolding.dto.PortfolioSummaryResponse;
+import com.hackathon.tomolow.domain.userMarketHolding.entity.UserMarketHolding;
+import com.hackathon.tomolow.domain.userMarketHolding.repository.UserMarketHoldingRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class HoldingQueryService {
+
+  private final UserMarketHoldingRepository holdingRepo;
+  private final PriceQueryService priceQueryService;
+
+  @Transactional(readOnly = true)
+  public HoldingsResponse getMyHoldings(User user) {
+    List<UserMarketHolding> holdings = holdingRepo.findAllByUser(user);
+
+    BigDecimal totalPnl = BigDecimal.ZERO;
+    BigDecimal totalInvestment = user.getInvestmentBalance(); // 고정값
+    BigDecimal cashBalance = user.getCashBalance(); // 고정값
+
+    for (UserMarketHolding h : holdings) {
+      BigDecimal cur = priceQueryService.getLastTradePriceOrThrow(h.getMarket().getSymbol());
+      BigDecimal qty = BigDecimal.valueOf(h.getQuantity());
+
+      BigDecimal invest = h.getAvgPrice().multiply(qty);
+      BigDecimal current = cur.multiply(qty);
+
+      BigDecimal pnl = current.subtract(invest); // 손익
+      totalPnl = totalPnl.add(pnl);
+    }
+
+    BigDecimal pnlRate =
+        totalInvestment.signum() == 0
+            ? BigDecimal.ZERO
+            : totalPnl.divide(totalInvestment, 4, RoundingMode.HALF_UP);
+
+    BigDecimal sumCurrent = BigDecimal.ZERO;
+    for (UserMarketHolding h : holdings) {
+      BigDecimal cur = priceQueryService.getLastTradePriceOrThrow(h.getMarket().getSymbol());
+      sumCurrent = sumCurrent.add(cur.multiply(BigDecimal.valueOf(h.getQuantity())));
+    }
+
+    PortfolioSummaryResponse portfolio =
+        PortfolioSummaryResponse.builder()
+            .totalInvestment(totalInvestment) // ✅ 투자자산 (고정)
+            .cashBalance(cashBalance) // ✅ 현금자산 (고정)
+            .totalPnlAmount(totalPnl) // ✅ 투자손익원
+            .totalPnlRate(pnlRate) // ✅ 투자손익률
+            // .totalCurrentValue(totalInvestment.add(cashBalance)) // ✅ 전체자산
+            .totalCurrentValue(cashBalance.add(sumCurrent)) // ✅ 현금 + 보유시가
+            .build();
+
+    return HoldingsResponse.builder()
+        .items(holdings.stream().map(this::toItem).toList()) // ✅ Stream으로 전체 변환
+        .portfolio(portfolio)
+        .build();
+  }
+
+  private HoldingItemResponse toItem(UserMarketHolding h) {
+    Market m = h.getMarket();
+
+    // 🔹 실시간 현재가(레디스) — 가격 없으면 예외
+    BigDecimal cur = priceQueryService.getLastTradePriceOrThrow(m.getSymbol());
+
+    BigDecimal qty = BigDecimal.valueOf(h.getQuantity());
+    BigDecimal invest = h.getAvgPrice().multiply(qty);
+    BigDecimal current = cur.multiply(qty);
+    BigDecimal pnl = current.subtract(invest);
+
+    BigDecimal pnlRate =
+        (invest.signum() == 0) ? BigDecimal.ZERO : pnl.divide(invest, 4, RoundingMode.HALF_UP);
+
+    return HoldingItemResponse.builder()
+        .marketId(m.getId())
+        .symbol(m.getSymbol())
+        .name(m.getName())
+        .imageUrl(m.getImgUrl()) // 컬럼/필드가 imgUrl 이라고 가정 (없으면 null)
+        .quantity(h.getQuantity())
+        .avgPrice(h.getAvgPrice())
+        .currentPrice(cur)
+        .pnlAmount(pnl.setScale(2, RoundingMode.HALF_UP))
+        .pnlRate(pnlRate)
+        .build();
+  }
+}

--- a/src/main/java/com/hackathon/tomolow/global/config/SecurityConfig.java
+++ b/src/main/java/com/hackathon/tomolow/global/config/SecurityConfig.java
@@ -62,7 +62,13 @@ public class SecurityConfig {
                     .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
                     .permitAll()
                     // 우리가 쓰는 파일/경로 추가 허용
-                    .requestMatchers("/", "/index.html", "/test.html", "/favicon.ico")
+                    .requestMatchers(
+                        "/",
+                        "/index.html",
+                        "/test.html",
+                        "/holding-test.html",
+                        "holding-ws-test.html",
+                        "/favicon.ico")
                     .permitAll()
                     .requestMatchers("/js/**", "/css/**", "/images/**", "/webjars/**")
                     .permitAll()

--- a/src/main/java/com/hackathon/tomolow/global/redis/RedisUtil.java
+++ b/src/main/java/com/hackathon/tomolow/global/redis/RedisUtil.java
@@ -58,4 +58,9 @@ public class RedisUtil {
     String value = getData(key);
     return value != null ? Long.parseLong(value) : 0L;
   }
+
+  // 추가
+  public org.springframework.data.redis.core.StringRedisTemplate getTemplate() {
+    return this.template;
+  }
 }

--- a/src/main/resources/static/holding-test.html
+++ b/src/main/resources/static/holding-test.html
@@ -1,0 +1,526 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8"/>
+  <title>보유 종목 실시간 테스트</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <script src="/js/sockjs.min.js"></script>
+  <script src="/js/stomp.umd.min.js"></script>
+  <style>
+    body {
+      font-family: ui-sans-serif, system-ui, -apple-system, Pretendard, sans-serif;
+      background: #fafafa;
+      margin: 0;
+      padding: 24px;
+      display: flex;
+      flex-direction: column;
+      align-items: center
+    }
+
+    .wrap {
+      width: 100%;
+      max-width: 980px
+    }
+
+    h1 {
+      margin: 0 0 6px;
+      font-size: 22px
+    }
+
+    .row {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+      align-items: center;
+      margin: 12px 0
+    }
+
+    input, button {
+      height: 36px;
+      padding: 0 12px;
+      border-radius: 10px;
+      border: 1px solid #ddd
+    }
+
+    button {
+      cursor: pointer;
+      background: #111;
+      color: #fff;
+      border: none
+    }
+
+    button.sec {
+      background: #eee;
+      color: #111
+    }
+
+    .status {
+      margin-left: 8px
+    }
+
+    .pill {
+      padding: 6px 10px;
+      border-radius: 999px;
+      font-size: 12px;
+      border: 1px solid #ddd;
+      background: #fff;
+      color: #333
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns:repeat(auto-fit, minmax(280px, 1fr));
+      gap: 12px
+    }
+
+    .card {
+      background: #fff;
+      border-radius: 16px;
+      padding: 16px 18px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, .08)
+    }
+
+    .name {
+      font-weight: 700;
+      margin-bottom: 6px;
+      font-size: 18px
+    }
+
+    .code {
+      color: #888;
+      margin-left: 4px
+    }
+
+    .price {
+      font-size: 28px;
+      font-weight: 800;
+      margin: 2px 0 6px
+    }
+
+    .sub {
+      font-size: 14px;
+      color: #555;
+      margin-bottom: 4px
+    }
+
+    .up {
+      color: #d93025
+    }
+
+    .down {
+      color: #0d904f
+    }
+
+    .table {
+      width: 100%;
+      border-collapse: separate;
+      border-spacing: 0 8px
+    }
+
+    .table th {
+      font-size: 12px;
+      color: #666;
+      text-align: left;
+      padding: 0 6px
+    }
+
+    .rowcard {
+      background: #fff;
+      border-radius: 12px;
+      box-shadow: 0 6px 18px rgba(0, 0, 0, .06)
+    }
+
+    .rowgrid {
+      display: grid;
+      grid-template-columns:140px 100px 100px 110px 110px 110px;
+      gap: 10px;
+      align-items: center;
+      padding: 12px
+    }
+
+    .right {
+      text-align: right
+    }
+
+    .mono {
+      font-variant-numeric: tabular-nums
+    }
+
+    .summary {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-top: 14px
+    }
+
+    .summary .card {
+      flex: 1;
+      min-width: 220px
+    }
+
+    pre#log {
+      background: #0b1020;
+      color: #cde2ff;
+      padding: 12px;
+      border-radius: 12px;
+      height: 160px;
+      overflow: auto
+    }
+
+    /* ==== FIX: 보유 종목 줄 잘림 방지 ==== */
+
+    /* 리스트는 필요한 경우 가로 스크롤 허용 */
+    #list {
+      display: block;
+      overflow-x: auto; /* 화면 좁을 때도 잘리지 않고 스크롤 가능 */
+      padding-bottom: 4px;
+    }
+
+    /* 카드 내부 그리드를 고정 px → 유동 fr 로 변경해 반응형 정렬 */
+    .rowgrid {
+      /* 종목 | 수량 | 평단 | 현재가 | 손익(원) | 손익률 */
+      grid-template-columns: 1.4fr 0.6fr 0.8fr 1fr 1fr 0.8fr;
+      column-gap: 14px;
+      min-width: 720px; /* 아주 좁은 화면에서는 스크롤로 보이도록 안전 폭 */
+    }
+
+    /* 숫자 폰트가 너무 커서 줄바꿈/잘림 나는 것 완화 */
+    .price {
+      font-size: 24px; /* 기존 28px → 24px */
+    }
+
+    /* 타이틀/값이 겹치지 않도록 작은 화면 보정 */
+    @media (max-width: 900px) {
+      .rowgrid {
+        min-width: 680px;
+      }
+
+      .price {
+        font-size: 22px;
+      }
+    }
+
+    @media (max-width: 600px) {
+      .rowgrid {
+        min-width: 640px;
+      }
+
+      .price {
+        font-size: 20px;
+      }
+    }
+  </style>
+</head>
+<body>
+<div class="wrap">
+  <h1>보유 종목 실시간 테스트</h1>
+  <div class="row">
+    <button id="btnLoad">보유현황 불러오기</button>
+    <button id="btnConnectWs">Connect (Native WS)</button>
+    <button id="btnConnectSock">Connect (SockJS)</button>
+    <button id="btnDisconnect" class="sec">Disconnect</button>
+    <span id="status" class="status">🔴 미연결</span>
+    <span id="transport" class="pill">transport: -</span>
+  </div>
+
+  <div class="summary" id="summary">
+    <div class="card">
+      <div class="name">현금자산</div>
+      <div class="price mono" id="cashBalance">-</div>
+      <div class="sub">서버 기준 고정값</div>
+    </div>
+    <div class="card">
+      <div class="name">투자자산(매입원금)</div>
+      <div class="price mono" id="investBalance">-</div>
+      <div class="sub">보유 종목 매입가 합계(고정)</div>
+    </div>
+    <div class="card">
+      <div class="name">총 손익(원)</div>
+      <div class="price mono" id="totalPnlAmount">-</div>
+      <div class="sub">= Σ(현재가×수량 - 평균매입×수량)</div>
+    </div>
+    <div class="card">
+      <div class="name">총 손익률</div>
+      <div class="price mono" id="totalPnlRate">-</div>
+      <div class="sub">= 총손익 ÷ 투자자산 (가중)</div>
+    </div>
+  </div>
+
+  <div style="margin-top:16px;">
+    <table class="table" style="width:100%;">
+      <thead>
+      <tr>
+        <th>종목</th>
+        <th class="right">수량</th>
+        <th class="right">평단</th>
+        <th class="right">현재가(실시간)</th>
+        <th class="right">손익(원)</th>
+        <th class="right">손익률</th>
+      </tr>
+      </thead>
+    </table>
+    <div id="list" class="grid" style="margin-top:6px;"></div>
+  </div>
+
+  <h3>로그</h3>
+  <pre id="log"></pre>
+</div>
+
+<script>
+  // ====== 환경 URL ======
+  const WS_NATIVE_URL = (location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host
+      + '/ws';
+  const SOCKJS_FULL_URL = location.origin + '/ws-sockjs';
+
+  // ====== 전역 상태 ======
+  let client = null;
+  let currentTransport = '-';
+  let holdings = null; // 서버에서 가져온 초기 보유데이터
+  const subs = {};     // 심볼별 구독 핸들
+
+  // ====== DOM ======
+  const el = (id) => document.getElementById(id);
+  const log = (m) => {
+    const p = el('log');
+    p.textContent += m + "\n";
+    p.scrollTop = p.scrollHeight;
+  }
+  const setStatus = (ok) => el('status').textContent = ok ? '🟢 연결됨' : '🔴 미연결';
+  const setTransport = (t) => {
+    currentTransport = t;
+    el('transport').textContent = 'transport: ' + t;
+  }
+  const fmt = (n) => Number(n ?? 0).toLocaleString('ko-KR');
+  const pct = (n) => (Number(n) >= 0 ? '+' : '') + (Number(n) * 100).toFixed(2) + '%';
+
+  // 가드: 0으로 나눔 방지
+  const safeDiv = (num, den) => {
+    const d = Number(den);
+    if (!isFinite(d) || Math.abs(d) < 1e-9) {
+      return 0;
+    }
+    return Number(num) / d;
+  };
+
+  // ====== STOMP 팩토리 ======
+  const STOMP = window.StompJs || window.Stomp;
+  const SockJSGlobal = window.SockJS || window.sockjs;
+
+  function createClientNative() {
+    return new STOMP.Client({
+      brokerURL: WS_NATIVE_URL,
+      reconnectDelay: 2000,
+      debug: (m) => log(m),
+      onConnect: () => {
+        setStatus(true);
+        setTransport('native');
+        log('✅ CONNECTED(native)');
+        subscribeAll();
+      },
+      onDisconnect: () => {
+        setStatus(false);
+        log('🔻 DISCONNECTED');
+      },
+      onStompError: (f) => {
+        log('❌ STOMP ERROR: ' + (f.headers?.message || ''));
+        log(f.body || '');
+      },
+      onWebSocketError: (e) => log('❌ WS ERROR: ' + (e?.message || e)),
+    });
+  }
+
+  function createClientSock() {
+    if (!SockJSGlobal) {
+      log('❌ SockJS 누락');
+      return null;
+    }
+    return new STOMP.Client({
+      webSocketFactory: () => new SockJSGlobal(SOCKJS_FULL_URL),
+      reconnectDelay: 2000,
+      debug: (m) => log(m),
+      onConnect: () => {
+        setStatus(true);
+        setTransport('sockjs');
+        log('✅ CONNECTED(sockjs)');
+        subscribeAll();
+      },
+      onDisconnect: () => {
+        setStatus(false);
+        log('🔻 DISCONNECTED');
+      },
+      onStompError: (f) => {
+        log('❌ STOMP ERROR: ' + (f.headers?.message || ''));
+        log(f.body || '');
+      },
+      onWebSocketError: (e) => log('❌ WS ERROR: ' + (e?.message || e)),
+    });
+  }
+
+  // ====== 보유현황 최초 로드 ======
+  async function loadHoldings() {
+    log('📥 fetching /api/mypage/holdings/my ...');
+    const token = "hereisuseraccesstoken"; // 🔐 DevTools -> Application -> Local Storage -> token 등에서 복사
+    const r = await fetch('/api/mypage/holdings/my', {
+      headers: {
+        'Authorization': 'Bearer ' + token
+      }
+    });
+    const j = await r.json();
+    holdings = j.data; // {items, portfolio}
+    renderHoldings(holdings);
+    // 연결되어 있다면 구독 새로 구성
+    if (client?.active) {
+      unsubscribeAll();
+      subscribeAll();
+    }
+  }
+
+  // ====== 렌더 ======
+  function renderHoldings(data) {
+    // 상단 요약(현금/투자/총손익/총손익률) — 서버값 반영
+    el('cashBalance').textContent = fmt(data.portfolio.cashBalance);
+    el('investBalance').textContent = fmt(data.portfolio.totalInvestment);
+    el('totalPnlAmount').textContent = fmt(data.portfolio.totalPnlAmount);
+    el('totalPnlRate').textContent = pct(data.portfolio.totalPnlRate);
+
+    // 리스트
+    const box = el('list');
+    box.innerHTML = '';
+    (data.items || []).forEach(item => {
+      const row = document.createElement('div');
+      row.className = 'rowcard';
+      row.id = 'row-' + item.symbol;
+
+      row.innerHTML = `
+        <div class="rowgrid">
+          <div>
+            <div class="name">${item.name}<span class="code">(${item.symbol})</span></div>
+          </div>
+          <div class="right mono" id="q-${item.symbol}">${fmt(item.quantity)}</div>
+          <div class="right mono" id="avg-${item.symbol}">${fmt(item.avgPrice)}</div>
+          <div class="right mono price" id="cur-${item.symbol}">${fmt(item.currentPrice)}</div>
+          <div class="right mono" id="pnl-${item.symbol}">${fmt(item.pnlAmount)}</div>
+          <div class="right mono" id="rate-${item.symbol}">${pct(item.pnlRate)}</div>
+        </div>
+      `;
+      box.appendChild(row);
+      updateRowColor(item.symbol, item.pnlAmount); // 색상
+    });
+  }
+
+  function updateRowColor(symbol, pnlAmount) {
+    const priceEl = el('cur-' + symbol);
+    const pnlEl = el('pnl-' + symbol);
+    const rateEl = el('rate-' + symbol);
+    const up = Number(pnlAmount) >= 0;
+    [priceEl, pnlEl, rateEl].forEach(e => {
+      if (!e) {
+        return;
+      }
+      e.classList.remove('up', 'down');
+      e.classList.add(up ? 'up' : 'down');
+    });
+  }
+
+  // ====== 구독/실시간 계산 ======
+  function subscribeAll() {
+    if (!client?.active || !holdings?.items) {
+      return;
+    }
+    holdings.items.forEach(it => {
+      const topic = '/topic/ticker/' + it.symbol;
+      if (subs[it.symbol]) {
+        return;
+      } // 이미 구독 중
+      subs[it.symbol] = client.subscribe(topic, (msg) => {
+        try {
+          const t = JSON.parse(msg.body); // TickerMessage
+          // 현재가 갱신
+          const cur = Number(t.tradePrice);
+          el('cur-' + it.symbol).textContent = fmt(cur);
+
+          // 보유 수량/평단
+          const qty = Number(it.quantity);
+          const avg = Number(it.avgPrice);
+
+          // 손익 원/률 재계산
+          const invest = avg * qty;
+          const current = cur * qty;
+          const pnlAmt = current - invest;
+          const pnlRate = safeDiv(pnlAmt, invest);
+
+          el('pnl-' + it.symbol).textContent = fmt(pnlAmt);
+          el('rate-' + it.symbol).textContent = pct(pnlRate);
+          updateRowColor(it.symbol, pnlAmt);
+
+          // 포트폴리오 합계(가중)
+          recalcPortfolio();
+        } catch (e) {
+          log('parse err: ' + e.message);
+        }
+      }, {id: 'sub-' + it.symbol});
+      log('🧷 SUB ' + topic);
+    });
+  }
+
+  function unsubscribeAll() {
+    Object.values(subs).forEach(s => s.unsubscribe());
+    for (const k in subs) {
+      delete subs[k];
+    }
+  }
+
+  function recalcPortfolio() {
+    if (!holdings) {
+      return;
+    }
+    const totalInvestment = Number(holdings.portfolio.totalInvestment || 0); // 고정
+    const cashBalance = Number(holdings.portfolio.cashBalance || 0);     // 고정
+
+    // Σ pnlAmount (DOM에서 읽어 합산)
+    let sumPnl = 0;
+    (holdings.items || []).forEach(it => {
+      const pnlText = el('pnl-' + it.symbol)?.textContent?.replaceAll(',', '') || '0';
+      sumPnl += Number(pnlText);
+    });
+
+    // 총손익률 = 총손익 / 투자자산 (가중)
+    const totalRate = safeDiv(sumPnl, totalInvestment);
+
+    el('totalPnlAmount').textContent = fmt(sumPnl);
+    el('totalPnlRate').textContent = pct(totalRate);
+
+    // 총 자산(표시용) = 투자자산 + 현금자산 (설명상 고정)
+    el('cashBalance').textContent = fmt(cashBalance);
+    el('investBalance').textContent = fmt(totalInvestment);
+  }
+
+  // ====== 버튼 ======
+  el('btnLoad').onclick = loadHoldings;
+  el('btnConnectWs').onclick = () => {
+    if (!STOMP) {
+      return;
+    }
+    if (client?.active) {
+      client.deactivate();
+    }
+    client = createClientNative();
+    client.activate();
+  };
+  el('btnConnectSock').onclick = () => {
+    if (!STOMP) {
+      return;
+    }
+    if (client?.active) {
+      client.deactivate();
+    }
+    client = createClientSock();
+    client?.activate();
+  };
+  el('btnDisconnect').onclick = () => client?.deactivate();
+
+  // 자동 시퀀스(선택): 진입 시 보유현황 먼저 로드
+  loadHoldings();
+</script>
+</body>
+</html>

--- a/src/main/resources/static/holding-ws-test.html
+++ b/src/main/resources/static/holding-ws-test.html
@@ -1,0 +1,509 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8"/>
+  <title>보유 종목 실시간 (서버 증분 계산 + 푸시)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <script src="/js/sockjs.min.js"></script>
+  <script src="/js/stomp.umd.min.js"></script>
+  <style>
+    :root {
+      --bg: #f7f7fb;
+      --card: #fff;
+      --ink: #111;
+      --muted: #666;
+      --line: #e7e7ef;
+      --up: #d93025;
+      --down: #0d904f;
+    }
+
+    * {
+      box-sizing: border-box
+    }
+
+    html, body {
+      height: 100%
+    }
+
+    body {
+      margin: 0;
+      padding: 20px;
+      background: var(--bg);
+      font-family: ui-sans-serif, system-ui, -apple-system, Pretendard, Segoe UI, Roboto, Apple SD Gothic Neo, Malgun Gothic, sans-serif;
+      color: var(--ink);
+      display: flex;
+      justify-content: center;
+    }
+
+    .wrap {
+      width: 100%;
+      max-width: 1080px
+    }
+
+    h1 {
+      margin: 0 0 10px;
+      font-size: 22px
+    }
+
+    .row {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+      align-items: center;
+      margin: 12px 0;
+    }
+
+    input, button {
+      height: 36px;
+      padding: 0 12px;
+      border-radius: 10px;
+      border: 1px solid var(--line);
+      background: #fff;
+    }
+
+    input {
+      min-width: 220px
+    }
+
+    button {
+      cursor: pointer;
+      background: #111;
+      color: #fff;
+      border: none;
+    }
+
+    button.sec {
+      background: #eee;
+      color: #111
+    }
+
+    .status {
+      margin-left: 6px
+    }
+
+    .pill {
+      padding: 6px 10px;
+      border-radius: 999px;
+      font-size: 12px;
+      border: 1px solid var(--line);
+      background: #fff;
+      color: #333;
+    }
+
+    .summary {
+      display: grid;
+      gap: 12px;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
+    .card {
+      background: var(--card);
+      border-radius: 16px;
+      padding: 16px 18px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, .08);
+      min-width: 0;
+    }
+
+    .name {
+      font-weight: 700;
+      margin-bottom: 6px;
+      font-size: 16px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis
+    }
+
+    .price {
+      font-size: 28px;
+      font-weight: 800;
+      margin: 2px 0 6px
+    }
+
+    .sub {
+      font-size: 13px;
+      color: var(--muted)
+    }
+
+    .table {
+      width: 100%;
+      border-collapse: separate;
+      border-spacing: 0 8px
+    }
+
+    .table th {
+      font-size: 12px;
+      color: #666;
+      text-align: left;
+      padding: 0 6px
+    }
+
+    .rowcard {
+      background: #fff;
+      border-radius: 12px;
+      box-shadow: 0 6px 18px rgba(0, 0, 0, .06);
+      overflow: hidden;
+    }
+
+    .rowgrid {
+      display: grid;
+      grid-template-columns: minmax(140px, 1fr) 100px 120px 140px 140px 120px;
+      gap: 10px;
+      align-items: center;
+      padding: 12px;
+      min-width: 0;
+    }
+
+    @media (max-width: 860px) {
+      .rowgrid {
+        grid-template-columns: 1.2fr .7fr .9fr 1fr 1fr .8fr
+      }
+    }
+
+    @media (max-width: 640px) {
+      .rowgrid {
+        grid-template-columns: 1.4fr .8fr .9fr 1fr 1fr
+      }
+
+      .col-hide {
+        display: none
+      }
+    }
+
+    .code {
+      color: #888;
+      margin-left: 4px;
+      font-weight: 500
+    }
+
+    .right {
+      text-align: right
+    }
+
+    .mono {
+      font-variant-numeric: tabular-nums
+    }
+
+    .nowrap {
+      white-space: nowrap
+    }
+
+    .clip {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap
+    }
+
+    .up {
+      color: var(--up)
+    }
+
+    .down {
+      color: var(--down)
+    }
+
+    .grid-list {
+      display: grid;
+      gap: 12px
+    }
+
+    pre#log {
+      background: #0b1020;
+      color: #cde2ff;
+      padding: 12px;
+      border-radius: 12px;
+      height: 160px;
+      overflow: auto;
+      font-size: 12px;
+    }
+
+    .grow {
+      flex: 1
+    }
+
+    .hint {
+      font-size: 12px;
+      color: #777;
+      margin-left: 6px
+    }
+  </style>
+</head>
+<body>
+<div class="wrap">
+  <h1>보유 종목 실시간 (서버 증분 계산 + 푸시)</h1>
+
+  <div class="row">
+    <input id="inpUserId" placeholder="userId (예: 5)"/>
+    <input id="inpToken" class="grow" placeholder="Bearer 토큰(JWT)"/>
+    <button id="btnLoad">보유현황 불러오기</button>
+  </div>
+
+  <div class="row">
+    <button id="btnConnectWs">Connect (Native WS)</button>
+    <button id="btnConnectSock">Connect (SockJS)</button>
+    <button id="btnDisconnect" class="sec">Disconnect</button>
+    <span id="status" class="status">🔴 미연결</span>
+    <span id="transport" class="pill">transport: -</span>
+    <span class="hint">연결 시 `/app/portfolio/online`으로 userId 등록</span>
+  </div>
+
+  <div class="summary" id="summary">
+    <div class="card">
+      <div class="name">현금자산</div>
+      <div class="price mono" id="cashBalance">-</div>
+      <div class="sub">서버 기준 고정값</div>
+    </div>
+    <div class="card">
+      <div class="name">투자자산(매입원금)</div>
+      <div class="price mono" id="investBalance">-</div>
+      <div class="sub">보유 종목 매입가 합계(고정)</div>
+    </div>
+    <div class="card">
+      <div class="name">총 손익(원)</div>
+      <div class="price mono" id="totalPnlAmount">-</div>
+      <div class="sub">= Σ(현재가×수량 - 평균매입×수량), 서버 증분 계산</div>
+    </div>
+    <div class="card">
+      <div class="name">총 손익률</div>
+      <div class="price mono" id="totalPnlRate">-</div>
+      <div class="sub">= 총손익 ÷ 투자자산 (가중), 서버 푸시</div>
+    </div>
+  </div>
+
+  <div style="margin-top:16px;">
+    <table class="table" style="width:100%;">
+      <thead>
+      <tr>
+        <th>종목</th>
+        <th class="right">수량</th>
+        <th class="right">평단</th>
+        <th class="right">현재가(실시간)</th>
+        <th class="right">손익(원)</th>
+        <th class="right col-hide">손익률</th>
+      </tr>
+      </thead>
+    </table>
+    <div id="list" class="grid-list" style="margin-top:6px;"></div>
+  </div>
+
+  <h3>로그</h3>
+  <pre id="log"></pre>
+</div>
+
+<script>
+  const WS_NATIVE_URL = (location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host
+      + '/ws';
+  const SOCKJS_FULL_URL = location.origin + '/ws-sockjs';
+  let client = null, holdings = null;
+  const subs = {};
+  const el = (id) => document.getElementById(id);
+  const log = (m) => {
+    const p = el('log');
+    p.textContent += m + "\n";
+    p.scrollTop = p.scrollHeight;
+  }
+  const fmt = (n) => Number(n ?? 0).toLocaleString('ko-KR');
+  const pct = (n) => (Number(n) >= 0 ? '+' : '') + (Number(n) * 100).toFixed(2) + '%';
+  const STOMP = window.StompJs || window.Stomp;
+  const SockJSGlobal = window.SockJS || window.sockjs;
+
+  function getUserId() {
+    const v = el('inpUserId').value.trim();
+    return v ? Number(v) : NaN;
+  }
+
+  // ✅ STOMP 방식 온라인 등록
+  function registerOnline() {
+    const uid = getUserId();
+    if (!client?.active || !isFinite(uid)) {
+      log('❌ 온라인 등록 실패: 연결/유저ID 확인');
+      return;
+    }
+    client.publish({destination: '/app/portfolio/online', body: String(uid)});
+    log('📡 STOMP /app/portfolio/online => ' + uid);
+    window.addEventListener('beforeunload', registerOffline);
+  }
+
+  function registerOffline() {
+    try {
+      const uid = getUserId();
+      if (!client?.active || !isFinite(uid)) {
+        return;
+      }
+      client.publish({destination: '/app/portfolio/offline', body: String(uid)});
+      log('📡 STOMP /app/portfolio/offline => ' + uid);
+    } catch (_) {
+    }
+  }
+
+  function createClientNative() {
+    return new STOMP.Client({
+      brokerURL: WS_NATIVE_URL,
+      reconnectDelay: 2000,
+      debug: (m) => log(m),
+      onConnect: () => {
+        log('✅ CONNECTED (native)');
+        registerOnline();
+        subscribePortfolio();
+        subscribeTickers();
+      },
+      onDisconnect: () => log('🔻 DISCONNECTED'),
+      onStompError: (f) => log('❌ STOMP ERROR: ' + (f.headers?.message || ''))
+    });
+  }
+
+  function createClientSock() {
+    return new STOMP.Client({
+      webSocketFactory: () => new SockJSGlobal(SOCKJS_FULL_URL),
+      reconnectDelay: 2000,
+      debug: (m) => log(m),
+      onConnect: () => {
+        log('✅ CONNECTED (SockJS)');
+        registerOnline();
+        subscribePortfolio();
+        subscribeTickers();
+      },
+      onDisconnect: () => log('🔻 DISCONNECTED')
+    });
+  }
+
+  async function loadHoldings() {
+    const token = el('inpToken').value.trim();
+    if (!token) {
+      alert('Bearer 토큰을 입력해주세요.');
+      return;
+    }
+    log('📥 GET /api/mypage/holdings/my');
+    const r = await fetch('/api/mypage/holdings/my',
+        {headers: {'Authorization': 'Bearer ' + token}});
+    if (!r.ok) {
+      alert('보유현황 요청 실패: ' + r.status);
+      return;
+    }
+    const j = await r.json();
+    holdings = j.data;
+    renderHoldings(holdings);
+    if (client?.active) {
+      unsubscribeAll();
+      subscribePortfolio();
+      subscribeTickers();
+      registerOnline();
+    }
+  }
+
+  function renderHoldings(data) {
+    el('cashBalance').textContent = fmt(data.portfolio.cashBalance);
+    el('investBalance').textContent = fmt(data.portfolio.totalInvestment);
+    el('totalPnlAmount').textContent = fmt(data.portfolio.totalPnlAmount);
+    el('totalPnlRate').textContent = pct(data.portfolio.totalPnlRate);
+    const box = el('list');
+    box.innerHTML = '';
+    (data.items || []).forEach(item => {
+      const row = document.createElement('div');
+      row.className = 'rowcard';
+      row.id = 'row-' + item.symbol;
+      row.innerHTML = `
+        <div class="rowgrid">
+          <div class="clip"><div class="name clip">${item.name}<span class="code">(${item.symbol})</span></div></div>
+          <div class="right mono nowrap" id="q-${item.symbol}">${fmt(item.quantity)}</div>
+          <div class="right mono nowrap" id="avg-${item.symbol}">${fmt(item.avgPrice)}</div>
+          <div class="right mono price nowrap" id="cur-${item.symbol}">${fmt(item.currentPrice)}</div>
+          <div class="right mono nowrap" id="pnl-${item.symbol}">${fmt(item.pnlAmount)}</div>
+          <div class="right mono nowrap col-hide" id="rate-${item.symbol}">${pct(item.pnlRate)}</div>
+        </div>`;
+      box.appendChild(row);
+      updateRowColor(item.symbol, item.pnlAmount);
+    });
+  }
+
+  function updateRowColor(symbol, pnlAmount) {
+    const els = ['cur-', 'pnl-', 'rate-'].map(p => el(p + symbol));
+    const up = Number(pnlAmount) >= 0;
+    els.forEach(e => {
+      if (e) {
+        e.classList.remove('up', 'down');
+        e.classList.add(up ? 'up' : 'down');
+      }
+    });
+  }
+
+  function subscribeTickers() {
+    if (!client?.active || !holdings?.items) {
+      return;
+    }
+    holdings.items.forEach(it => {
+      const topic = '/topic/ticker/' + it.symbol;
+      if (subs[it.symbol]) {
+        return;
+      }
+      subs[it.symbol] = client.subscribe(topic, (msg) => {
+        const t = JSON.parse(msg.body);
+        const cur = Number(t.tradePrice);
+        el('cur-' + it.symbol).textContent = fmt(cur);
+        const qty = Number(it.quantity), avg = Number(it.avgPrice);
+        const pnlAmt = cur * qty - avg * qty, pnlRate = avg === 0 ? 0 : (pnlAmt / (avg * qty));
+        el('pnl-' + it.symbol).textContent = fmt(pnlAmt);
+        const rateEl = el('rate-' + it.symbol);
+        if (rateEl) {
+          rateEl.textContent = pct(pnlRate);
+        }
+        updateRowColor(it.symbol, pnlAmt);
+      });
+      log('🧷 SUB ' + topic);
+    });
+  }
+
+  function subscribePortfolio() {
+    const uid = getUserId();
+    if (!client?.active || !isFinite(uid)) {
+      return;
+    }
+    const topic = '/topic/portfolio/' + uid;
+    if (subs['portfolio']) {
+      subs['portfolio'].unsubscribe();
+    }
+    subs['portfolio'] = client.subscribe(topic, (msg) => {
+      const p = JSON.parse(msg.body);
+      el('totalPnlAmount').textContent = fmt(p.totalPnlAmount);
+      el('totalPnlRate').textContent = pct(p.totalPnlRate);
+    });
+    log('🧷 SUB ' + topic);
+  }
+
+  function unsubscribeAll() {
+    Object.values(subs).forEach(s => {
+      try {
+        s.unsubscribe();
+      } catch (_) {
+      }
+    });
+    for (const k in subs) {
+      delete subs[k];
+    }
+  }
+
+  el('btnLoad').onclick = loadHoldings;
+  el('btnConnectWs').onclick = () => {
+    if (client?.active) {
+      client.deactivate();
+    }
+    client = createClientNative();
+    client.activate();
+  };
+  el('btnConnectSock').onclick = () => {
+    if (client?.active) {
+      client.deactivate();
+    }
+    client = createClientSock();
+    client.activate();
+  };
+  el('btnDisconnect').onclick = () => {
+    registerOffline();
+    if (client?.active) {
+      client.deactivate();
+    }
+    unsubscribeAll();
+  };
+</script>
+</body>
+</html>


### PR DESCRIPTION
## #️⃣ 연관 이슈

> #24 

## 📝 작업 내용

- [ ] 실시간 총손익/총손익률 ‘절대 계산’ 즉시 푸시
> 	•	틱/체결에 반응해 해당 심볼 보유 + 온라인 유저만 선별 푸시
	•	분모(투자자산)는 DB(User.investmentBalance), 분자는 Redis 시세로 계산
- [ ] ws:online 세트 도입/활용 → 온라인 접속해있는 유저에게만 푸시하도록 구현 -> 푸시 대상은 보유 + 온라인으로 좁힘
- [ ] 프론트 테스트 코드 작성

## 📊 로직 흐름도
[업비트 WS] ── 틱 수신 (symbol, price)
      │
      ▼
[UpbitTickerService]
  - last_price:{symbol}, ticker:{symbol} 갱신(REDIS)
  - /topic/ticker/{symbol} 브로드캐스트(개별 종목 실시간가)
  - PriceTickDispatcher.onTick(symbol, price) 호출
      │
      ▼
[PriceTickDispatcher]
  - 심볼 단일 실행(세마포어) + coalesce
  - MatchService.matchByMarketPrice(marketId, price)
      │
      ▼
[MatchService] (체결 로직)
  - 지정가 매수/매도 매칭 및 체결
  - User, Holding, Transaction JPA 갱신
  - PortfolioRedisService에 포지션 미러/보유세트 업데이트
  - portfolioPnlService.reindexUserHoldings(userId)
  - portfolioPnlService.pushPnlAndSeedBaseline(userId)  ← ★ 즉시 총손익/손익률 푸시
      │
      │(체결과 무관하게 틱으로 인해 포트폴리오 요약이 필요할 때)
      ▼
[PortfolioPnlService.pushPnlForSymbol(symbol)]
  - holders:{symbol} ∩ ws:online 만 선별
  - 각 userId에 대해 pushPnlAndSeedBaseline(userId) 수행(즉시 푸시)
      │
      ▼
/STOMP 브로커
  - /topic/portfolio/{userId} 로 PortfolioPnlMessage 송신
      │
      ▼
[클라이언트(HTML)]
  - /topic/ticker/{symbol} 구독 → 행 실시간 가격/손익 갱신
  - /topic/portfolio/{userId} 구독 → 총손익/총손익률 실시간 갱신
  - 최초 접속 시 /app/portfolio/online(userId) 송신 → 서버가 인덱스 재작성+초기 1회 푸시

## 💬 리뷰 요구사항

- [ ] 종목을 2개 매수하고, 1개만 매도 시, 전체자산이 제대로 반영되지 않는 오류가 발생해, MatchService 부분을 수정했습니다 !!

## 📸 스크린샷
