### PR TITLE
✨ 관심(하트) 토글 및 관심 마켓 목록 API 추가

### DIFF
--- a/src/main/java/com/hackathon/tomolow/domain/userInterestedMarket/controller/UserInterestController.java
+++ b/src/main/java/com/hackathon/tomolow/domain/userInterestedMarket/controller/UserInterestController.java
@@ -1,0 +1,59 @@
+package com.hackathon.tomolow.domain.userInterestedMarket.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.hackathon.tomolow.domain.userInterestedMarket.dto.InterestToggleResponse;
+import com.hackathon.tomolow.domain.userInterestedMarket.dto.InterestedMarketCard;
+import com.hackathon.tomolow.domain.userInterestedMarket.dto.InterestedMarketListResponse;
+import com.hackathon.tomolow.domain.userInterestedMarket.service.UserInterestService;
+import com.hackathon.tomolow.global.response.BaseResponse;
+import com.hackathon.tomolow.global.security.CustomUserDetails;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/interests")
+@Tag(name = "관심(하트)", description = "관심 마켓 등록/해제 및 조회 API")
+public class UserInterestController {
+
+  private final UserInterestService userInterestService;
+
+  @PostMapping("/markets/{marketId}/toggle")
+  @Operation(summary = "하트 토글", description = "해당 마켓을 관심 등록/해제한다.")
+  public ResponseEntity<BaseResponse<InterestToggleResponse>> toggle(
+      @AuthenticationPrincipal CustomUserDetails ud, @PathVariable Long marketId) {
+
+    var res = userInterestService.toggle(ud.getUser().getId(), marketId);
+    return ResponseEntity.ok(BaseResponse.success("OK", res));
+  }
+
+  @GetMapping("/markets")
+  @Operation(summary = "관심 목록 조회", description = "사용자의 관심 마켓 목록을 조회한다.")
+  public ResponseEntity<BaseResponse<InterestedMarketListResponse>> list(
+      @AuthenticationPrincipal CustomUserDetails ud) {
+
+    List<InterestedMarketCard> items = userInterestService.list(ud.getUser().getId());
+    return ResponseEntity.ok(BaseResponse.success("OK", new InterestedMarketListResponse(items)));
+  }
+
+  // (선택) 단건 상태 확인
+  @GetMapping("/markets/{marketId}/status")
+  @Operation(summary = "관심 여부 확인", description = "해당 마켓이 관심 등록 상태인지 반환한다.")
+  public ResponseEntity<BaseResponse<Boolean>> status(
+      @AuthenticationPrincipal CustomUserDetails ud, @PathVariable Long marketId) {
+
+    boolean interested = userInterestService.isInterested(ud.getUser().getId(), marketId);
+    return ResponseEntity.ok(BaseResponse.success("OK", interested));
+  }
+}

--- a/src/main/java/com/hackathon/tomolow/domain/userInterestedMarket/dto/InterestToggleResponse.java
+++ b/src/main/java/com/hackathon/tomolow/domain/userInterestedMarket/dto/InterestToggleResponse.java
@@ -1,0 +1,21 @@
+package com.hackathon.tomolow.domain.userInterestedMarket.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(title = "관심 토글 결과", description = "관심 등록/해제 요청의 처리 결과")
+public class InterestToggleResponse {
+
+  @Schema(description = "관심 상태 (true=관심 등록됨)", example = "true")
+  private boolean interested;
+
+  @Schema(description = "대상 마켓 ID", example = "12")
+  private Long marketId;
+}

--- a/src/main/java/com/hackathon/tomolow/domain/userInterestedMarket/dto/InterestedMarketCard.java
+++ b/src/main/java/com/hackathon/tomolow/domain/userInterestedMarket/dto/InterestedMarketCard.java
@@ -1,0 +1,27 @@
+package com.hackathon.tomolow.domain.userInterestedMarket.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(title = "관심 마켓 카드", description = "관심 목록에 노출되는 간단 카드 정보")
+public class InterestedMarketCard {
+
+  @Schema(description = "마켓 ID", example = "2")
+  private Long marketId;
+
+  @Schema(description = "심볼 (코드)", example = "KRW-ETH")
+  private String symbol;
+
+  @Schema(description = "마켓 이름", example = "이더리움")
+  private String name;
+
+  @Schema(description = "마켓 이미지 URL", example = "https://.../eth.png")
+  private String imageUrl;
+}

--- a/src/main/java/com/hackathon/tomolow/domain/userInterestedMarket/dto/InterestedMarketListResponse.java
+++ b/src/main/java/com/hackathon/tomolow/domain/userInterestedMarket/dto/InterestedMarketListResponse.java
@@ -1,0 +1,16 @@
+package com.hackathon.tomolow.domain.userInterestedMarket.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(title = "관심 마켓 목록 응답")
+public class InterestedMarketListResponse {
+
+  @Schema(description = "관심 마켓 목록")
+  private java.util.List<InterestedMarketCard> items;
+}

--- a/src/main/java/com/hackathon/tomolow/domain/userInterestedMarket/repository/UserInterestedMarketRepository.java
+++ b/src/main/java/com/hackathon/tomolow/domain/userInterestedMarket/repository/UserInterestedMarketRepository.java
@@ -1,7 +1,19 @@
 package com.hackathon.tomolow.domain.userInterestedMarket.repository;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.hackathon.tomolow.domain.userInterestedMarket.entity.UserInterestedMarket;
 
-public interface UserInterestedMarketRepository extends JpaRepository<UserInterestedMarket, Long> {}
+public interface UserInterestedMarketRepository extends JpaRepository<UserInterestedMarket, Long> {
+
+  boolean existsByUser_IdAndMarket_Id(Long userId, Long marketId);
+
+  Optional<UserInterestedMarket> findByUser_IdAndMarket_Id(Long userId, Long marketId);
+
+  void deleteByUser_IdAndMarket_Id(Long userId, Long marketId);
+
+  List<UserInterestedMarket> findAllByUser_IdOrderByCreatedAtDesc(Long userId);
+}

--- a/src/main/java/com/hackathon/tomolow/domain/userInterestedMarket/service/UserInterestService.java
+++ b/src/main/java/com/hackathon/tomolow/domain/userInterestedMarket/service/UserInterestService.java
@@ -1,0 +1,74 @@
+package com.hackathon.tomolow.domain.userInterestedMarket.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.hackathon.tomolow.domain.market.entity.Market;
+import com.hackathon.tomolow.domain.market.exception.MarketErrorCode;
+import com.hackathon.tomolow.domain.market.repository.MarketRepository;
+import com.hackathon.tomolow.domain.user.entity.User;
+import com.hackathon.tomolow.domain.user.exception.UserErrorCode;
+import com.hackathon.tomolow.domain.user.repository.UserRepository;
+import com.hackathon.tomolow.domain.userInterestedMarket.dto.InterestToggleResponse;
+import com.hackathon.tomolow.domain.userInterestedMarket.dto.InterestedMarketCard;
+import com.hackathon.tomolow.domain.userInterestedMarket.entity.UserInterestedMarket;
+import com.hackathon.tomolow.domain.userInterestedMarket.repository.UserInterestedMarketRepository;
+import com.hackathon.tomolow.global.exception.CustomException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserInterestService {
+
+  private final UserRepository userRepository;
+  private final MarketRepository marketRepository;
+  private final UserInterestedMarketRepository interestRepo;
+
+  /** 하트 토글: 없으면 생성, 있으면 삭제 */
+  @Transactional
+  public InterestToggleResponse toggle(Long userId, Long marketId) {
+    var exists = interestRepo.existsByUser_IdAndMarket_Id(userId, marketId);
+    if (exists) {
+      interestRepo.deleteByUser_IdAndMarket_Id(userId, marketId);
+      return new InterestToggleResponse(false, marketId);
+    }
+
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+    Market market =
+        marketRepository
+            .findById(marketId)
+            .orElseThrow(() -> new CustomException(MarketErrorCode.MARKET_NOT_FOUND));
+
+    var entity = UserInterestedMarket.builder().user(user).market(market).build();
+    interestRepo.save(entity);
+
+    return new InterestToggleResponse(true, marketId);
+  }
+
+  /** 내 관심 마켓 목록 */
+  @Transactional(readOnly = true)
+  public List<InterestedMarketCard> list(Long userId) {
+    return interestRepo.findAllByUser_IdOrderByCreatedAtDesc(userId).stream()
+        .map(
+            im ->
+                InterestedMarketCard.builder()
+                    .marketId(im.getMarket().getId())
+                    .symbol(im.getMarket().getSymbol())
+                    .name(im.getMarket().getName())
+                    .imageUrl(im.getMarket().getImgUrl())
+                    .build())
+        .toList();
+  }
+
+  /** 특정 마켓이 관심인지 단건 조회 (마켓 리스트 화면에서 하트 ON/OFF 표시에 필요하면 사용) */
+  @Transactional(readOnly = true)
+  public boolean isInterested(Long userId, Long marketId) {
+    return interestRepo.existsByUser_IdAndMarket_Id(userId, marketId);
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관 이슈

> #이슈번호

## 📝 작업 내용

- [ ] POST /api/interests/markets/{marketId}/toggle : 관심 등록/해제 토글
- [ ] GET  /api/interests/markets : 내 관심 마켓 목록 조회
- [ ] (opt) GET /api/interests/markets/{id}/status : 단건 관심 여부 확인

## 💬 리뷰 요구사항

- [ ] ex) ~부분은 무엇으로 통일하는 게 좋을가요?
- [ ] 요구사항 2

## 📸 스크린샷
