### PR TITLE
:sparkles: 거래대금/거래량/급상승/급하락 기준 실시간 랭킹 정렬 구현

### DIFF
--- a/src/main/java/com/hackathon/tomolow/domain/market/controller/RankingController.java
+++ b/src/main/java/com/hackathon/tomolow/domain/market/controller/RankingController.java
@@ -1,0 +1,34 @@
+package com.hackathon.tomolow.domain.market.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.hackathon.tomolow.domain.market.service.RankingService;
+import com.hackathon.tomolow.global.response.BaseResponse;
+import com.hackathon.tomolow.global.security.CustomUserDetails;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/rank")
+public class RankingController {
+
+  private final RankingService rankingService;
+
+  @GetMapping("/{type}") // type: turnover|volume|gainers|losers
+  public ResponseEntity<?> top(
+      @PathVariable String type,
+      @RequestParam(defaultValue = "50") int limit,
+      @AuthenticationPrincipal CustomUserDetails user) {
+    Long userId = (user == null) ? null : user.getUser().getId();
+    return ResponseEntity.ok(
+        BaseResponse.success(
+            "랭킹 조회 성공", rankingService.getTopWithInterest(type, Math.min(limit, 100), userId)));
+  }
+}

--- a/src/main/java/com/hackathon/tomolow/domain/market/dto/RankItem.java
+++ b/src/main/java/com/hackathon/tomolow/domain/market/dto/RankItem.java
@@ -1,0 +1,46 @@
+package com.hackathon.tomolow.domain.market.dto;
+
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(Include.NON_NULL) // ✅ null 필드는 JSON에서 제거
+@Schema(description = "실시간 랭킹 아이템")
+public class RankItem {
+
+  @Schema(description = "마켓 심볼", example = "KRW-BTC")
+  private String symbol;
+
+  @Schema(description = "마켓 이름", example = "비트코인")
+  private String name;
+
+  @Schema(description = "마켓 이미지 URL")
+  private String imageUrl; // ✅ 추가
+
+  @Schema(description = "현재가")
+  private BigDecimal price;
+
+  @Schema(description = "전일 대비 등락률 (0.0123 = +1.23%)")
+  private BigDecimal changeRate;
+
+  @Schema(description = "전일 대비 등락 원")
+  private BigDecimal changePrice;
+
+  @Schema(description = "관심등록 여부", example = "true")
+  private Boolean interested; // ✅ Boolean로 바꾸면 null 가능, 🔸 개인화(REST 초기 1회에서만 채움, STOMP는 null)
+
+  public static RankItem ofSymbolOnly(String s) {
+    return RankItem.builder().symbol(s).name(s).price(BigDecimal.ZERO).build();
+  }
+}

--- a/src/main/java/com/hackathon/tomolow/domain/market/repository/MarketRepository.java
+++ b/src/main/java/com/hackathon/tomolow/domain/market/repository/MarketRepository.java
@@ -16,4 +16,6 @@ public interface MarketRepository extends JpaRepository<Market, Long> {
 
   // 업비트에 등록된 마켓만 가져오기
   List<Market> findAllByExchangeType(ExchangeType exchangeType);
+
+  List<Market> findAllBySymbolIn(Iterable<String> symbols);
 }

--- a/src/main/java/com/hackathon/tomolow/domain/market/service/RankingService.java
+++ b/src/main/java/com/hackathon/tomolow/domain/market/service/RankingService.java
@@ -1,0 +1,193 @@
+package com.hackathon.tomolow.domain.market.service;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hackathon.tomolow.domain.market.dto.RankItem;
+import com.hackathon.tomolow.domain.market.entity.Market;
+import com.hackathon.tomolow.domain.market.repository.MarketRepository;
+import com.hackathon.tomolow.domain.ticker.dto.TickerMessage;
+import com.hackathon.tomolow.domain.userInterestedMarket.entity.UserInterestedMarket;
+import com.hackathon.tomolow.domain.userInterestedMarket.repository.UserInterestedMarketRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RankingService {
+
+  private final StringRedisTemplate redis;
+  private final ObjectMapper om;
+  private final SimpMessagingTemplate broker;
+  private final MarketRepository marketRepository;
+  private final UserInterestedMarketRepository interestedRepo;
+
+  private static final String Z_TURNOVER = "rank:turnover"; // 거래대금
+  private static final String Z_VOLUME = "rank:volume"; // 거래량
+  private static final String Z_GAINERS = "rank:gainers"; // 급상승
+  private static final String Z_LOSERS = "rank:losers"; // 급하락
+
+  // ============ 점수 업데이트 ============
+  public void onTick(TickerMessage t) {
+    String sym = t.getMarket();
+    double sTurnover = nz(t.getAccTradePrice24h());
+    double sVolume = nz(t.getAccVolume());
+    double sGainers = nz(t.getChangeRate()); // changeRate 높을수록 상위
+    double sLosers = -nz(t.getChangeRate()); // 하락폭 큰(음수 절대값 큼) 것 상위
+
+    redis.opsForZSet().add(Z_TURNOVER, sym, sTurnover);
+    redis.opsForZSet().add(Z_VOLUME, sym, sVolume);
+    redis.opsForZSet().add(Z_GAINERS, sym, sGainers);
+    redis.opsForZSet().add(Z_LOSERS, sym, sLosers);
+  }
+
+  private double nz(BigDecimal v) {
+    return (v == null ? 0d : v.doubleValue());
+  }
+
+  // ============ 공용: TOP N (관심여부 없음) ============
+  @Transactional(readOnly = true)
+  public List<RankItem> getTopPublic(String type, int limit) {
+    String key = pickKey(type);
+    Set<String> syms = redis.opsForZSet().reverseRange(key, 0, limit - 1);
+    if (syms == null || syms.isEmpty()) return List.of();
+
+    // 심볼→마켓 캐시
+    Map<String, Market> marketMap =
+        marketRepository.findAllBySymbolIn(syms).stream()
+            .collect(Collectors.toMap(Market::getSymbol, m -> m));
+
+    return syms.stream().map(sym -> toRankItem(sym, marketMap, null)).toList();
+  }
+
+  // ============ 개인화: TOP N (관심여부 포함) ============
+  @Transactional(readOnly = true)
+  public List<RankItem> getTopWithInterest(String type, int limit, Long userId) {
+    String key = pickKey(type);
+    Set<String> syms = redis.opsForZSet().reverseRange(key, 0, limit - 1);
+    if (syms == null || syms.isEmpty()) return List.of();
+
+    Map<String, Market> marketMap =
+        marketRepository.findAllBySymbolIn(syms).stream()
+            .collect(Collectors.toMap(Market::getSymbol, m -> m));
+
+    // 유저 관심 마켓 id → boolean map
+    Map<Long, Boolean> interestedMap =
+        (userId == null)
+            ? Map.of()
+            : interestedRepo.findAllByUser_Id(userId).stream()
+                .map(UserInterestedMarket::getMarket)
+                .collect(Collectors.toMap(Market::getId, m -> Boolean.TRUE, (a, b) -> a));
+
+    return syms.stream().map(sym -> toRankItem(sym, marketMap, interestedMap)).toList();
+  }
+
+  private RankItem toRankItem(
+      String symbol, Map<String, Market> marketMap, Map<Long, Boolean> interestedMapOrNull) {
+    try {
+      String json = redis.opsForValue().get("ticker:" + symbol);
+      if (json == null) {
+        Market m = marketMap.get(symbol);
+        return RankItem.builder()
+            .symbol(symbol)
+            .name(m != null ? m.getName() : symbol)
+            .imageUrl(m != null ? m.getImgUrl() : null)
+            .price(BigDecimal.ZERO)
+            .build();
+      }
+      var t = om.readTree(json); // 가볍게 읽기
+      Market m = marketMap.get(symbol);
+
+      Boolean interested = null;
+      if (interestedMapOrNull != null && m != null) {
+        interested = interestedMapOrNull.getOrDefault(m.getId(), Boolean.FALSE);
+      }
+
+      return RankItem.builder()
+          .symbol(symbol)
+          .name(m != null ? m.getName() : symbol)
+          .imageUrl(m != null ? m.getImgUrl() : null)
+          .price(readBig(t, "tradePrice"))
+          .changeRate(readBig(t, "changeRate"))
+          .changePrice(readBig(t, "changePrice"))
+          .interested(interested) // 🔸 REST 초기 1회에서만 세팅, STOMP는 null
+          .build();
+    } catch (Exception e) {
+      Market m = marketMap.get(symbol);
+      return RankItem.builder()
+          .symbol(symbol)
+          .name(m != null ? m.getName() : symbol)
+          .imageUrl(m != null ? m.getImgUrl() : null)
+          .price(BigDecimal.ZERO)
+          .build();
+    }
+  }
+
+  private BigDecimal readBig(com.fasterxml.jackson.databind.JsonNode n, String field) {
+    var v = n.get(field);
+    return (v == null || v.isNull()) ? BigDecimal.ZERO : v.decimalValue();
+  }
+
+  private String pickKey(String type) {
+    return switch (type) {
+      case "turnover" -> Z_TURNOVER;
+      case "volume" -> Z_VOLUME;
+      case "gainers" -> Z_GAINERS;
+      case "losers" -> Z_LOSERS;
+      default -> Z_TURNOVER;
+    };
+  }
+
+  // ============ 1초 코얼레싱 푸시(공용) ============
+  private volatile String lastTurnoverPayload = "";
+  private volatile String lastVolumePayload = "";
+  private volatile String lastGainersPayload = "";
+  private volatile String lastLosersPayload = "";
+
+  @Scheduled(fixedDelay = 1000L)
+  public void pushTopEverySec() {
+    pushIfChanged(
+        "/topic/rank/turnover",
+        lastTurnoverPayload,
+        p -> lastTurnoverPayload = p,
+        getTopPublic("turnover", 50));
+    pushIfChanged(
+        "/topic/rank/volume",
+        lastVolumePayload,
+        p -> lastVolumePayload = p,
+        getTopPublic("volume", 50));
+    pushIfChanged(
+        "/topic/rank/gainers",
+        lastGainersPayload,
+        p -> lastGainersPayload = p,
+        getTopPublic("gainers", 50));
+    pushIfChanged(
+        "/topic/rank/losers",
+        lastLosersPayload,
+        p -> lastLosersPayload = p,
+        getTopPublic("losers", 50));
+  }
+
+  private void pushIfChanged(
+      String topic, String last, Consumer<String> setLast, List<RankItem> list) {
+    try {
+      String payload = om.writeValueAsString(list);
+      if (!payload.equals(last)) {
+        setLast.accept(payload);
+        broker.convertAndSend(topic, payload);
+      }
+    } catch (Exception ignored) {
+    }
+  }
+}

--- a/src/main/java/com/hackathon/tomolow/domain/ticker/dto/TickerMessage.java
+++ b/src/main/java/com/hackathon/tomolow/domain/ticker/dto/TickerMessage.java
@@ -13,6 +13,7 @@ import lombok.Setter;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+// @JsonIgnoreProperties(ignoreUnknown = true) -> 필드 추가로 인해 오류가 난다면 추가하기
 public class TickerMessage {
 
   private String market; // 예: KRW-BTC
@@ -24,5 +25,6 @@ public class TickerMessage {
   private BigDecimal prevClose; // 전일 종가
 
   private BigDecimal accVolume; // 누적 거래량(24h) (수량)
+  private BigDecimal accTradePrice24h; // ✅ acc_trade_price_24h (KRW)
   private long tradeTimestamp; // 틱 시각(ms)
 }

--- a/src/main/java/com/hackathon/tomolow/domain/userInterestedMarket/repository/UserInterestedMarketRepository.java
+++ b/src/main/java/com/hackathon/tomolow/domain/userInterestedMarket/repository/UserInterestedMarketRepository.java
@@ -16,4 +16,7 @@ public interface UserInterestedMarketRepository extends JpaRepository<UserIntere
   void deleteByUser_IdAndMarket_Id(Long userId, Long marketId);
 
   List<UserInterestedMarket> findAllByUser_IdOrderByCreatedAtDesc(Long userId);
+
+  // 로그인 유저의 관심 마켓 id 목록 조회
+  List<UserInterestedMarket> findAllByUser_Id(Long userId);
 }


### PR DESCRIPTION
## #️⃣ 연관 이슈

> #이슈번호

## 📝 작업 내용

- [x] 거래대금/거래량/급상승/급하락 기준 실시간 정렬 구현
- [x] Redis ZSET 기반 랭킹 관리 및 1초 단위 STOMP 푸시(pushTopEverySec) 추가
- [x] Market 이미지, 관심여부(interested) 포함한 REST 초기 응답 추가
- [x] RankingController: 로그인 유저 기반 개인화 랭킹 조회 지원
- [x] RankItem DTO: imageUrl, interested 필드 추가 및 null 필드 제외 설정
- [x] TickerMessage: accTradePrice24h 필드 추가 (거래대금 계산용)
- [x] UpbitTickerService: 랭킹 업데이트 트리거(rankingService.onTick) 연동

## 🔄 로직 흐름
1️⃣ 실시간 데이터 수집
	•	UpbitTickerService
	•	업비트 WebSocket(wss://api.upbit.com/websocket/v1)으로 실시간 시세 수신
	•	수신된 틱 데이터를 TickerMessage로 변환
	•	Redis에 ticker:{symbol}로 저장
	•	rankingService.onTick(dto) 호출 → 랭킹 점수 갱신
	•	/topic/ticker/{symbol} STOMP 브로드캐스트

⸻

2️⃣ 랭킹 점수 계산
	•	RankingService.onTick()
	•	accTradePrice24h, accVolume, changeRate 값을 기반으로
	•	거래대금(rank:turnover)
	•	거래량(rank:volume)
	•	급상승(rank:gainers)
	•	급하락(rank:losers)
	•	각각 Redis ZSET에 점수로 저장 (opsForZSet().add())

⸻

3️⃣ 초기 진입 시 (REST)
	•	GET /api/rank/{type}
	•	로그인 유저라면 관심마켓(UserInterestedMarket) 목록을 함께 조회
	•	MarketRepository.findAllBySymbolIn()으로 이미지/이름 등 한 번에 로드
	•	응답 데이터에 imageUrl, interested 포함
	•	프론트는 이 데이터를 첫 진입 시 렌더링용으로 사용

⸻

4️⃣ 실시간 업데이트 (STOMP)
	•	@Scheduled(fixedDelay = 1000) pushTopEverySec()
	•	1초마다 Redis ZSET을 조회하여 랭킹 리스트 생성
	•	이전 payload와 비교해 변경이 있으면 /topic/rank/{type}으로 브로드캐스트
	•	이때 interested는 항상 null → 프론트는 기존 하트 상태 그대로 유지

⸻

## 🎨 프론트 로직 요약

초기 렌더링
	1.	진입 시 GET /api/rank/{type} 호출
	2.	각 마켓 카드에
	•	이미지(imageUrl)
	•	이름(name)
	•	현재가(price)
	•	등락률(changeRate)
	•	관심여부(interested) 렌더링
	3.	이후 /topic/rank/{type} 구독 시작

⸻

실시간 반영
	1.	STOMP로 /topic/rank/{type} 수신
	2.	기존 리스트에서:
	•	가격, 등락률, 순위만 업데이트
	•	관심여부(하트)는 유지
	3.	변경된 순서대로 카드 재정렬 (애니메이션 처리 선택 가능)

⸻

## 💬 리뷰 요구사항

- [ ] ex) ~부분은 무엇으로 통일하는 게 좋을가요?
- [ ] 요구사항 2

## 📸 스크린샷
