### PR TITLE
:recycle: 관심 종목 리스트에 현재가격과 등락율 조회 추가

### DIFF
--- a/src/main/java/com/hackathon/tomolow/domain/userInterestedMarket/dto/InterestedMarketCard.java
+++ b/src/main/java/com/hackathon/tomolow/domain/userInterestedMarket/dto/InterestedMarketCard.java
@@ -1,5 +1,7 @@
 package com.hackathon.tomolow.domain.userInterestedMarket.dto;
 
+import java.math.BigDecimal;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -24,4 +26,10 @@ public class InterestedMarketCard {
 
   @Schema(description = "마켓 이미지 URL", example = "https://.../eth.png")
   private String imageUrl;
+
+  @Schema(description = "현재가", example = "87000")
+  private BigDecimal currentPrice; // ✅ 추가
+
+  @Schema(description = "등락률 (소수, 예: 0.105는 +10.5%)", example = "0.105")
+  private BigDecimal changeRate; // ✅ 추가
 }


### PR DESCRIPTION
## #️⃣ 연관 이슈

> 프론트 요청으로 관심 종목 리스트 불러오기에서, 현재가격과 등락율 조회 추가

## 📝 작업 내용

- [ ] dto 수정
- [ ] service 코드 수정

## 💬 리뷰 요구사항

- [ ] ex) ~부분은 무엇으로 통일하는 게 좋을가요?
- [ ] 요구사항 2

## 📸 스크린샷
