### PR TITLE
:sparkles: 그룹 내 개인 거래내역 조회 api 구현

### DIFF
--- a/src/main/java/com/hackathon/tomolow/domain/userGroupTransaction/controller/GroupTradeHistoryController.java
+++ b/src/main/java/com/hackathon/tomolow/domain/userGroupTransaction/controller/GroupTradeHistoryController.java
@@ -1,0 +1,62 @@
+package com.hackathon.tomolow.domain.userGroupTransaction.controller;
+
+import java.time.LocalDate;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.hackathon.tomolow.domain.transaction.dto.TradeHistoryResponse;
+import com.hackathon.tomolow.domain.userGroupTransaction.service.GroupTradeHistoryService;
+import com.hackathon.tomolow.global.response.BaseResponse;
+import com.hackathon.tomolow.global.security.CustomUserDetails;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+@RequestMapping("/api/group")
+@Tag(name = "Group Trade History", description = "그룹 내 개인 거래내역 조회 API")
+public class GroupTradeHistoryController {
+
+  private final GroupTradeHistoryService groupTradeHistoryService;
+
+  @Operation(
+      summary = "그룹 기간별 거래내역 조회",
+      description = "특정 그룹에서, 시작일~종료일 동안의 내 매수/매도 내역과 기간 손익 요약을 조회합니다.")
+  @GetMapping("/{groupId}/transactions/history")
+  public ResponseEntity<BaseResponse<TradeHistoryResponse>> getGroupTradeHistory(
+      @PathVariable Long groupId,
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+      @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+
+    Long userId = userDetails.getUser().getId();
+    TradeHistoryResponse resp =
+        groupTradeHistoryService.getHistory(userId, groupId, startDate, endDate);
+
+    return ResponseEntity.ok(BaseResponse.success("그룹 거래내역 조회 성공", resp));
+  }
+
+  @Operation(
+      summary = "그룹 기본 범위 거래내역 조회",
+      description = "해당 그룹에서의 내 첫 거래일 ~ 오늘 날짜까지의 거래내역과 손익을 조회합니다.")
+  @GetMapping("/{groupId}/transactions/history/default")
+  public ResponseEntity<BaseResponse<TradeHistoryResponse>> getGroupDefaultTradeHistory(
+      @PathVariable Long groupId, @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+    Long userId = userDetails.getUser().getId();
+    TradeHistoryResponse resp = groupTradeHistoryService.getDefaultHistory(userId, groupId);
+
+    return ResponseEntity.ok(BaseResponse.success("그룹 거래내역(기본 범위) 조회 성공", resp));
+  }
+}

--- a/src/main/java/com/hackathon/tomolow/domain/userGroupTransaction/repository/UserGroupTransactionRepository.java
+++ b/src/main/java/com/hackathon/tomolow/domain/userGroupTransaction/repository/UserGroupTransactionRepository.java
@@ -1,9 +1,21 @@
 package com.hackathon.tomolow.domain.userGroupTransaction.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.hackathon.tomolow.domain.userGroup.entity.UserGroup;
 import com.hackathon.tomolow.domain.userGroupTransaction.entity.UserGroupTransaction;
 
 public interface UserGroupTransactionRepository extends JpaRepository<UserGroupTransaction, Long> {
   boolean existsByUserGroup_Group_Id(Long groupId);
+
+  // 기간별 거래내역 (최신순)
+  List<UserGroupTransaction> findAllByUserGroupAndCreatedAtBetweenOrderByCreatedAtDesc(
+      UserGroup userGroup, LocalDateTime start, LocalDateTime end);
+
+  // 해당 UserGroup의 첫 거래 하나 (createdAt 오름차순)
+  Optional<UserGroupTransaction> findFirstByUserGroupOrderByCreatedAtAsc(UserGroup userGroup);
 }

--- a/src/main/java/com/hackathon/tomolow/domain/userGroupTransaction/service/GroupTradeHistoryService.java
+++ b/src/main/java/com/hackathon/tomolow/domain/userGroupTransaction/service/GroupTradeHistoryService.java
@@ -1,0 +1,133 @@
+package com.hackathon.tomolow.domain.userGroupTransaction.service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.hackathon.tomolow.domain.transaction.dto.DailyTradeHistoryDto;
+import com.hackathon.tomolow.domain.transaction.dto.TradeHistoryItemDto;
+import com.hackathon.tomolow.domain.transaction.dto.TradeHistoryResponse;
+import com.hackathon.tomolow.domain.transaction.entity.TradeType;
+import com.hackathon.tomolow.domain.userGroup.entity.UserGroup;
+import com.hackathon.tomolow.domain.userGroupTransaction.entity.UserGroupTransaction;
+import com.hackathon.tomolow.domain.userGroupTransaction.repository.UserGroupTransactionRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GroupTradeHistoryService {
+
+  private final UserGroupTransactionRepository userGroupTransactionRepository;
+  private final GroupOrderInfoService groupOrderInfoService;
+
+  /** 🔹 특정 그룹에서의 내 거래내역 (기간 지정) */
+  @Transactional(readOnly = true)
+  public TradeHistoryResponse getHistory(
+      Long userId, Long groupId, LocalDate startDate, LocalDate endDate) {
+
+    // 1) UserGroup 조회 (이미 다른 서비스에서 쓰던 헬퍼 재사용)
+    UserGroup userGroup = groupOrderInfoService.getUserGroup(userId, groupId);
+
+    // 2) 날짜 범위를 LocalDateTime으로 변환  [start, end)
+    LocalDateTime start = startDate.atStartOfDay();
+    LocalDateTime end = endDate.plusDays(1).atStartOfDay();
+
+    // 3) 해당 그룹 내 내 거래내역 조회 (최신순)
+    List<UserGroupTransaction> txs =
+        userGroupTransactionRepository.findAllByUserGroupAndCreatedAtBetweenOrderByCreatedAtDesc(
+            userGroup, start, end);
+
+    BigDecimal totalBuy = BigDecimal.ZERO;
+    BigDecimal totalSell = BigDecimal.ZERO;
+
+    List<TradeHistoryItemDto> items = new ArrayList<>();
+
+    for (UserGroupTransaction tx : txs) {
+      BigDecimal amount = tx.getPrice().multiply(BigDecimal.valueOf(tx.getQuantity()));
+
+      if (tx.getTradeType() == TradeType.BUY) {
+        totalBuy = totalBuy.add(amount);
+      } else {
+        totalSell = totalSell.add(amount);
+      }
+
+      items.add(
+          TradeHistoryItemDto.builder()
+              .tradedAt(tx.getCreatedAt()) // ✅ 개인과 동일: tradedAt
+              .name(tx.getMarket().getName())
+              .symbol(tx.getMarket().getSymbol())
+              .price(tx.getPrice())
+              .quantity(tx.getQuantity())
+              .tradeType(tx.getTradeType())
+              .amount(amount)
+              .build());
+    }
+
+    BigDecimal periodPnl = totalSell.subtract(totalBuy);
+
+    BigDecimal pnlRate =
+        (totalBuy.signum() == 0)
+            ? BigDecimal.ZERO
+            : periodPnl.divide(totalBuy, 4, RoundingMode.HALF_UP);
+
+    // 4) 날짜별 그룹핑 (최신 날짜 순)
+    Map<LocalDate, List<TradeHistoryItemDto>> byDate =
+        items.stream()
+            .collect(
+                Collectors.groupingBy(
+                    i -> i.getTradedAt().toLocalDate(), // ✅ tradedAt 기준
+                    LinkedHashMap::new,
+                    Collectors.toList()));
+
+    List<DailyTradeHistoryDto> days =
+        byDate.entrySet().stream()
+            .sorted(Map.Entry.<LocalDate, List<TradeHistoryItemDto>>comparingByKey().reversed())
+            .map(e -> DailyTradeHistoryDto.builder().date(e.getKey()).items(e.getValue()).build())
+            .toList();
+
+    return TradeHistoryResponse.builder()
+        .periodPnlAmount(periodPnl)
+        .periodPnlRate(pnlRate)
+        .totalBuyAmount(totalBuy)
+        .totalSellAmount(totalSell)
+        .days(days)
+        .build();
+  }
+
+  /** 🔹 그룹 내 기본 범위(첫 거래일 ~ 오늘) */
+  @Transactional(readOnly = true)
+  public TradeHistoryResponse getDefaultHistory(Long userId, Long groupId) {
+
+    UserGroup userGroup = groupOrderInfoService.getUserGroup(userId, groupId);
+
+    var firstTxOpt =
+        userGroupTransactionRepository.findFirstByUserGroupOrderByCreatedAtAsc(userGroup);
+
+    // 거래가 없으면 빈 응답
+    if (firstTxOpt.isEmpty()) {
+      return TradeHistoryResponse.builder()
+          .periodPnlAmount(BigDecimal.ZERO)
+          .periodPnlRate(BigDecimal.ZERO)
+          .totalBuyAmount(BigDecimal.ZERO)
+          .totalSellAmount(BigDecimal.ZERO)
+          .days(List.of())
+          .build();
+    }
+
+    LocalDate firstDate = firstTxOpt.get().getCreatedAt().toLocalDate();
+    LocalDate today = LocalDate.now();
+
+    // 🌟 개인과 똑같이: "첫 거래일 ~ 오늘" 범위로 재사용
+    return getHistory(userId, groupId, firstDate, today);
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관 이슈

> #103 

## 📝 작업 내용

- [ ] 거래내역 첫 호출 시, 거래내역 조회 api 추가
- [ ] 추가로 날짜 지정해서 호출 시의 거래내역 조회 api 추가

## 💬 리뷰 요구사항

- [ ] ex) ~부분은 무엇으로 통일하는 게 좋을가요?
- [ ] 요구사항 2

## 📸 스크린샷
